### PR TITLE
Agent Configuration

### DIFF
--- a/collector/agent_poller.go
+++ b/collector/agent_poller.go
@@ -102,7 +102,6 @@ func NewAgent(
 // This function should be run as a gofunc.
 func (a *Agent) Run(recordsChan chan<- *AvroDatum, stats chan<- StatsEvent) {
 	// fetch agent ip once. per DC/OS docs, changing a node IP is unsupported
-	a.AgentIP = ""
 	if len(*agentTestStateFileFlag) == 0 ||
 		len(*agentTestSystemFileFlag) == 0 ||
 		len(*agentTestContainersFileFlag) == 0 {

--- a/collector/agent_poller.go
+++ b/collector/agent_poller.go
@@ -76,7 +76,7 @@ func NewAgent(
 	pollPeriod int,
 	topic string) (Agent, error) {
 	a := Agent{}
-	if len(ipCommand) < 0 {
+	if len(ipCommand) == 0 {
 		return a, errors.New("Must pass ipAddress to NewAgent()")
 	}
 	if port < 1024 {
@@ -85,7 +85,7 @@ func NewAgent(
 	if pollPeriod == 0 {
 		return a, errors.New("Must pass pollPeriod to NewAgent()")
 	}
-	if len(topic) < 1 {
+	if len(topic) == 0 {
 		return a, errors.New("Must pass topic to NewAgent()")
 	}
 

--- a/collector/cmd/dcos-metrics-collector/config.go
+++ b/collector/cmd/dcos-metrics-collector/config.go
@@ -72,6 +72,7 @@ func getNewConfig(args []string) (CollectorConfig, error) {
 	if err := c.loadConfig(); err != nil {
 		return c, err
 	}
+	fmt.Printf("%+v", c)
 
 	return c, nil
 }

--- a/collector/cmd/dcos-metrics-collector/config.go
+++ b/collector/cmd/dcos-metrics-collector/config.go
@@ -72,7 +72,6 @@ func getNewConfig(args []string) (CollectorConfig, error) {
 	if err := c.loadConfig(); err != nil {
 		return c, err
 	}
-	fmt.Printf("%+v", c)
 
 	return c, nil
 }

--- a/collector/cmd/dcos-metrics-collector/config.go
+++ b/collector/cmd/dcos-metrics-collector/config.go
@@ -8,18 +8,35 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-type ConfigFile struct {
-	PollAgent     bool `yaml:"poll_agent"`
-	HttpProfiler  bool `yaml:"http_profiler"`
-	KafkaProducer bool `yaml:"kafka_producer"`
-	ConfigPath    string
+type MasterConfig struct {
+	Port  int    `yaml:"port,omitempty"`
+	Topic string `yaml:"metric_topic,omitempty"`
 }
 
-func (c *ConfigFile) setFlags(fs *flag.FlagSet) {
+type AgentConfig struct {
+	Port  int    `yaml:"port,omitempty"`
+	Topic string `yaml:"metric_topic,omitempty"`
+}
+
+type CollectorConfig struct {
+	HttpProfiler  bool   `yaml:"http_profiler"`
+	KafkaProducer bool   `yaml:"kafka_producer"`
+	IpCommand     string `yaml:"ip_command"`
+	PollingPeriod int    `yaml:"polling_period"`
+
+	AgentConfig  AgentConfig  `yaml:"agent_config,omitempty"`
+	MasterConfig MasterConfig `yaml:"master_config,omitempty"`
+
+	ConfigPath string
+	DCOSRole   string
+}
+
+func (c *CollectorConfig) setFlags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ConfigPath, "config", c.ConfigPath, "The path to the config file.")
+	fs.StringVar(&c.DCOSRole, "role", c.DCOSRole, "The DC/OS role this instance runs on.")
 }
 
-func (c *ConfigFile) loadConfig() error {
+func (c *CollectorConfig) loadConfig() error {
 	fmt.Printf("Loading config file from %s\n", c.ConfigPath)
 	fileByte, err := ioutil.ReadFile(c.ConfigPath)
 	if err != nil {
@@ -32,17 +49,18 @@ func (c *ConfigFile) loadConfig() error {
 	return nil
 }
 
-func defaultConfig() ConfigFile {
-	return ConfigFile{
-		PollAgent:     true,
+func newConfig() CollectorConfig {
+	return CollectorConfig{
 		HttpProfiler:  true,
 		KafkaProducer: true,
+		PollingPeriod: 15,
+		IpCommand:     "/opt/mesosphere/bin/detect_ip",
 		ConfigPath:    "dcos-metrics-config.yaml",
 	}
 }
 
-func parseArgsReturnConfig(args []string) (ConfigFile, error) {
-	c := defaultConfig()
+func getNewConfig(args []string) (CollectorConfig, error) {
+	c := newConfig()
 	thisFlagSet := flag.NewFlagSet("", flag.PanicOnError)
 	c.setFlags(thisFlagSet)
 	// Override default config with CLI flags if any
@@ -50,8 +68,10 @@ func parseArgsReturnConfig(args []string) (ConfigFile, error) {
 		fmt.Println("Errors encountered parsing flags.")
 		return c, err
 	}
+
 	if err := c.loadConfig(); err != nil {
 		return c, err
 	}
+
 	return c, nil
 }

--- a/collector/cmd/dcos-metrics-collector/config_test.go
+++ b/collector/cmd/dcos-metrics-collector/config_test.go
@@ -4,17 +4,11 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
 )
 
 func TestDefaultConfig(t *testing.T) {
 	testConfig := newConfig()
-
-	testFileType := reflect.TypeOf(testConfig)
-	if testFileType.Name() != "CollectorConfig" {
-		t.Error("defaultConfig() should return ConfigFile type, got", testFileType.Name())
-	}
 
 	if testConfig.PollingPeriod != 15 {
 		t.Error("Expected polling period to be 15 by default")

--- a/collector/cmd/dcos-metrics-collector/dcos-metrics-collector.go
+++ b/collector/cmd/dcos-metrics-collector/dcos-metrics-collector.go
@@ -30,7 +30,16 @@ func main() {
 	agentStateChan := make(chan *collector.AgentState)
 	if collectorConfig.DCOSRole == "agent" {
 		log.Printf("Agent polling enabled")
-		go collector.RunAgentPoller(recordInputChan, agentStateChan, stats)
+		agent, err := collector.NewAgent(
+			collectorConfig.IpCommand,
+			collectorConfig.AgentConfig.Port,
+			collectorConfig.PollingPeriod,
+			collectorConfig.AgentConfig.Topic)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		go agent.Run(recordInputChan, stats)
 	}
 	go collector.RunAvroTCPReader(recordInputChan, stats)
 

--- a/collector/cmd/dcos-metrics-collector/dcos-metrics-collector.go
+++ b/collector/cmd/dcos-metrics-collector/dcos-metrics-collector.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	collectorConfig, err := parseArgsReturnConfig(os.Args[1:])
+	collectorConfig, err := getNewConfig(os.Args[1:])
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
@@ -28,7 +28,7 @@ func main() {
 
 	recordInputChan := make(chan *collector.AvroDatum)
 	agentStateChan := make(chan *collector.AgentState)
-	if collectorConfig.PollAgent {
+	if collectorConfig.DCOSRole == "agent" {
 		log.Printf("Agent polling enabled")
 		go collector.RunAgentPoller(recordInputChan, agentStateChan, stats)
 	}

--- a/collector/cmd/dcos-metrics-collector/example-dcos-metrics-collector.yaml
+++ b/collector/cmd/dcos-metrics-collector/example-dcos-metrics-collector.yaml
@@ -3,4 +3,4 @@ kafka_producer: false
 polling_period: 5
 agent_config:
   port: 1234
-  topic: foo-topic
+  metric_topic: foo-topic

--- a/collector/cmd/dcos-metrics-collector/example-dcos-metrics-collector.yaml
+++ b/collector/cmd/dcos-metrics-collector/example-dcos-metrics-collector.yaml
@@ -1,3 +1,6 @@
-poll_agent: true
-http_profiler_enabled: false
-kafka_flag_enabled: false
+http_profiler: false
+kafka_producer: false
+polling_period: 5
+agent_config:
+  port: 1234
+  topic: foo-topic

--- a/collector/host_helpers.go
+++ b/collector/host_helpers.go
@@ -1,0 +1,29 @@
+package collector
+
+type HostCollectorConfig struct {
+	MesosRole      string
+	MesosPort      int
+	MesosEndpoints map[string]string
+	// Maybe testing config too? Unsure how those flags currently work.
+}
+
+type HostMetrics struct {
+	Memory  string
+	CPU     string
+	Storage string
+}
+
+type Host struct {
+	IPAddress string
+	Hostname  string
+	Metrics   HostMetrics
+	Config    HostCollectorConfig
+}
+
+func (h *Host) SetIP() error { return nil }
+
+func (h *Host) SetHostname() error { return nil }
+
+func (h *Host) SetConfig(role string, port int, endpoints map[string]string) error { return nil }
+
+func (h *Host) GetHostMetrics() error { return nil }


### PR DESCRIPTION
"The Big Plan"(TM) - break down agent_poller.go piece by piece, forming a complete Agent{} struct with methods on it that can be broken out into a generic `HostPoller interface{}` later so we can build a Master version. This first bit removes the library level flags, and instead passes them into the library through the `NewAgent() -> Agent{}` construct. 

- [x] Agent poller becomes a obejct
- [x] Agent poller sets config from executable code
- [x] Refactor code to enable master poller and generic role interface in the future