### PR TITLE
Add ping endpoint for reverse proxies

### DIFF
--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/dcos/dcos-metrics/producers"
 	"github.com/gorilla/mux"
@@ -109,6 +110,16 @@ func containerSingleMetricHandler(p *producerImpl) http.HandlerFunc {
 		}
 		cm.Datapoints = datapoints
 		encode(cm, w)
+	}
+}
+
+func pingHandler(p *producerImpl) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		type ping struct {
+			OK        bool   `json:"ok"`
+			Timestamp string `json:"timestamp"`
+		}
+		encode(ping{OK: true, Timestamp: time.Now().UTC().Format(time.RFC3339)}, w)
 	}
 }
 

--- a/producers/http/routes.go
+++ b/producers/http/routes.go
@@ -51,6 +51,14 @@ var routes = []Route{
 	// "/", "/api", and "/api/v0" that has usage info and available endpoints
 	// provided by this service.
 
+	// Ping endpoin
+	Route{
+		Name:        "ping",
+		Method:      "GET",
+		Path:        strings.Join([]string{root, "ping"}, "/"),
+		HandlerFunc: pingHandler,
+	},
+
 	// Agent Endpoints, e.g. /api/v0/agent...
 	Route{
 		Name:        "agent",


### PR DESCRIPTION
Can be used by reverse proxies to determine backend service health.