### PR TITLE
Add Master Polling Functionality

### DIFF
--- a/collector/mesos.go
+++ b/collector/mesos.go
@@ -112,12 +112,12 @@ type resourceStatistics struct {
 
 // getContainerMetrics queries an agent for container-level metrics, such as
 // CPU, memory, disk, and network usage.
-func (a *Agent) getContainerMetrics() ([]agentContainer, error) {
+func (h *DCOSHost) getContainerMetrics() ([]agentContainer, error) {
 	var containers []agentContainer
 
 	// TODO(roger): 15sec timeout is a guess. Is there a better way to do this?
 	c := NewHTTPClient(
-		strings.Join([]string{a.AgentIP, strconv.Itoa(a.Port)}, ":"),
+		strings.Join([]string{h.IPAddress, strconv.Itoa(h.Port)}, ":"),
 		"/containers",
 		time.Duration(15*time.Second))
 	if err := c.Fetch(&containers); err != nil {
@@ -130,12 +130,12 @@ func (a *Agent) getContainerMetrics() ([]agentContainer, error) {
 // getAgentState fetches the state JSON from the Mesos agent, which contains
 // info such as framework names and IDs, the current leader, config flags,
 // container (executor) labels, and more.
-func (a *Agent) getAgentState() (agentState, error) {
+func (h *DCOSHost) getAgentState() (agentState, error) {
 	state := agentState{}
 
 	// TODO(roger): 15sec timeout is a guess. Is there a better way to do this?
 	c := NewHTTPClient(
-		strings.Join([]string{a.AgentIP, strconv.Itoa(a.Port)}, ":"),
+		strings.Join([]string{h.IPAddress, strconv.Itoa(h.Port)}, ":"),
 		"/state",
 		time.Duration(15*time.Second))
 	if err := c.Fetch(&state); err != nil {

--- a/collector/mesos_test.go
+++ b/collector/mesos_test.go
@@ -98,7 +98,7 @@ func TestGetContainerMetrics(t *testing.T) {
 			panic(err)
 		}
 
-		a, _ := NewAgent("/bin/echo -n 127.0.0.1", port, 60, make(chan<- producers.MetricsMessage))
+		a, _ := NewDCOSHost("agent", "/bin/echo -n 127.0.0.1", port, 60, make(chan<- producers.MetricsMessage))
 		result, err := a.getContainerMetrics()
 
 		Convey("Should return an array of 'agentContainer' without error", func() {
@@ -128,8 +128,8 @@ func TestGetAgentState(t *testing.T) {
 		}
 
 		Convey("Should return an 'agentState' without error", func() {
-			a, _ := NewAgent("/bin/echo -n 127.0.0.1", port, 60, make(chan<- producers.MetricsMessage))
-			result, err := a.getAgentState()
+			h, _ := NewDCOSHost("agent", "/bin/echo -n 127.0.0.1", port, 60, make(chan<- producers.MetricsMessage))
+			result, err := h.getAgentState()
 
 			// getAgentState() returns a lot of metadata required for dcos-metrics
 			// to be useful to operators. Let's ensure that we're unmarshaling

--- a/collector/node.go
+++ b/collector/node.go
@@ -76,7 +76,7 @@ type nodeNetworkInterface struct {
 	TxErrors  uint64 `json:"network.{{.Name}}.out.errors"`
 }
 
-func (a *Agent) getNodeMetrics() (nodeMetrics, error) {
+func (h *DCOSHost) getNodeMetrics() (nodeMetrics, error) {
 	l := getLoadAvg()
 	cpuStatePcts := calculatePcts(getCPUTimes())
 	m := getMemory()

--- a/collector/node_collector_test.go
+++ b/collector/node_collector_test.go
@@ -66,26 +66,26 @@ func TestBuildDatapoints(t *testing.T) {
 	})
 }
 
-func TestNewAgent(t *testing.T) {
-	Convey("When establishing a new agentPoller", t, func() {
+func TestNewDCOSHost(t *testing.T) {
+	Convey("When establishing a new DCOSHost object", t, func() {
 		Convey("Should return an error when given an improper ip-detect command", func() {
-			_, err := NewAgent("", 10000, 60, make(chan<- producers.MetricsMessage))
+			_, err := NewDCOSHost("agent", "", 10000, 60, make(chan<- producers.MetricsMessage))
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Should return an error when given an improper port", func() {
-			_, err := NewAgent("/bin/echo -n 1.2.3.4", 1023, 60, make(chan<- producers.MetricsMessage))
+			_, err := NewDCOSHost("agent", "/bin/echo -n 1.2.3.4", 1023, 60, make(chan<- producers.MetricsMessage))
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Should return an error when given an improper pollPeriod", func() {
-			_, err := NewAgent("/bin/echo -n 1.2.3.4", 1024, 0, make(chan<- producers.MetricsMessage))
+			_, err := NewDCOSHost("agent", "/bin/echo -n 1.2.3.4", 1024, 0, make(chan<- producers.MetricsMessage))
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Should return an Agent when given proper inputs", func() {
-			a, err := NewAgent("/bin/echo -n 1.2.3.4", 10000, 60, make(chan<- producers.MetricsMessage))
-			So(a, ShouldHaveSameTypeAs, Agent{})
+			a, err := NewDCOSHost("agent", "/bin/echo -n 1.2.3.4", 10000, 60, make(chan<- producers.MetricsMessage))
+			So(a, ShouldHaveSameTypeAs, DCOSHost{})
 			So(err, ShouldBeNil)
 		})
 	})
@@ -94,8 +94,8 @@ func TestNewAgent(t *testing.T) {
 func TestGetIP(t *testing.T) {
 	Convey("When getting the agent IP address using the ip_detect script", t, func() {
 		Convey("Should return the IP address without error", func() {
-			a := Agent{IPCommand: "/bin/echo -n 172.16.10.88"}
-			i, err := a.getIP()
+			h := DCOSHost{IPCommand: "/bin/echo -n 172.16.10.88"}
+			i, err := h.getIP()
 			So(i, ShouldEqual, "172.16.10.88")
 			So(err, ShouldBeNil)
 		})
@@ -105,7 +105,7 @@ func TestGetIP(t *testing.T) {
 func TestTransform(t *testing.T) {
 	Convey("When transforming agent metrics to fit producers.MetricsMessage", t, func() {
 		// bogus port and IP address here; no HTTP client in a.transform()
-		a, _ := NewAgent("/bin/echo -n 127.0.0.1", 9000, 60, make(chan<- producers.MetricsMessage))
+		h, _ := NewDCOSHost("agent", "/bin/echo -n 127.0.0.1", 9000, 60, make(chan<- producers.MetricsMessage))
 
 		// The mocks in this test file are bytearrays so that they can be used
 		// by the HTTP test server(s). So we need to unmarshal them here before
@@ -131,7 +131,7 @@ func TestTransform(t *testing.T) {
 		}
 
 		Convey("Should return a []producers.MetricsMessage without errors", func() {
-			result := a.transform(testData)
+			result := h.transform(testData)
 			So(len(result), ShouldEqual, 2) // one agent message, one container message
 
 			// From the implementation of a.transform() and the mocks in this test file,

--- a/examples/configs/dcos-metrics-config-example.yaml
+++ b/examples/configs/dcos-metrics-config-example.yaml
@@ -5,8 +5,8 @@
 # Collector configuration
 collector:
   http_profiler: false
-  ip_command: 'cat /etc/mesos-slave/ip'
-  polling_period: 15
+  ip_command: 'echo 10.1.2.3'
+  polling_period: 1 
 
   # DC/OS (Mesos) master configuration
   master_config:

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -25,13 +25,13 @@ import (
 )
 
 // /api/v0/agent
-func agentHandler(p *producerImpl) http.HandlerFunc {
+func nodeHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var am []interface{}
-		if agentMetrics, err := p.store.GetByRegex(producers.AgentMetricPrefix + ".*"); err != nil {
+		if nodeMetrics, err := p.store.GetByRegex(producers.NodeMetricPrefix + ".*"); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 		} else {
-			for _, v := range agentMetrics {
+			for _, v := range nodeMetrics {
 				am = append(am, v)
 			}
 			encode(am[0], w)

--- a/producers/http/http_test.go
+++ b/producers/http/http_test.go
@@ -35,7 +35,7 @@ func TestHTTPProducer_Agent(t *testing.T) {
 	testTime := time.Now()
 
 	testData := producers.MetricsMessage{
-		Name: producers.AgentMetricPrefix,
+		Name: producers.NodeMetricPrefix,
 		Datapoints: []producers.Datapoint{
 			producers.Datapoint{
 				Name:      "some-metric",
@@ -45,7 +45,7 @@ func TestHTTPProducer_Agent(t *testing.T) {
 			},
 		},
 		Dimensions: producers.Dimensions{
-			AgentID:  "foo",
+			MesosID:  "foo",
 			Hostname: "some-host",
 		},
 		Timestamp: testTime.UTC().Unix(),
@@ -56,14 +56,14 @@ func TestHTTPProducer_Agent(t *testing.T) {
 		panic(err)
 	}
 
-	Convey("When querying the /system/metrics/api/v0/agent endpoint", t, func() {
+	Convey("When querying the /system/metrics/api/v0/node endpoint", t, func() {
 		Convey("Should return metrics in the expected structure", func() {
 			pi, pc := New(Config{IP: "127.0.0.1", Port: port, CacheExpiry: time.Duration(5) * time.Second})
 			go pi.Run()
 			time.Sleep(1 * time.Second) // give the http server a chance to start before querying it
 
 			pc <- testData
-			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/system/metrics/api/v0/agent", port))
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/system/metrics/api/v0/node", port))
 			if err != nil {
 				panic(err)
 			}

--- a/producers/http/logger.go
+++ b/producers/http/logger.go
@@ -17,8 +17,6 @@ package http
 import (
 	"net/http"
 	"time"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 func logger(inner http.Handler, name string) http.Handler {
@@ -27,7 +25,7 @@ func logger(inner http.Handler, name string) http.Handler {
 
 		inner.ServeHTTP(w, r)
 
-		log.Printf(
+		httpLog.Printf(
 			"%s\t%s\t%s\t%s",
 			r.Method,
 			r.RequestURI,

--- a/producers/http/router.go
+++ b/producers/http/router.go
@@ -17,18 +17,12 @@ package http
 import (
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 )
 
-// NewRouter iterates over a slice of Route types and creates them
-// in gorilla/mux.
-func newRouter(p *producerImpl) *mux.Router {
-
-	router := mux.NewRouter().StrictSlash(true)
-	// Various HTTP routes defined in routes.go
+func loadRoutes(routes []Route, router *mux.Router, p *producerImpl) {
 	for _, route := range routes {
-		log.Debugf("http producer: establishing endpoint %s at %s", route.Name, route.Path)
+		httpLog.Debugf("http producer: establishing endpoint %s at %s", route.Name, route.Path)
 		var handler http.Handler
 
 		handler = route.HandlerFunc(p)
@@ -40,6 +34,18 @@ func newRouter(p *producerImpl) *mux.Router {
 			Name(route.Name).
 			Handler(handler)
 	}
+}
+
+// NewRouter iterates over a slice of Route types and creates them
+// in gorilla/mux.
+func newRouter(p *producerImpl) *mux.Router {
+
+	router := mux.NewRouter().StrictSlash(true)
+	if p.config.DCOSRole == "agent" {
+		loadRoutes(agentRoutes, router, p)
+	}
+
+	loadRoutes(routes, router, p)
 
 	return router
 }

--- a/producers/http/routes.go
+++ b/producers/http/routes.go
@@ -61,12 +61,14 @@ var routes = []Route{
 
 	// Agent Endpoints, e.g. /api/v0/agent...
 	Route{
-		Name:        "agent",
+		Name:        "node",
 		Method:      "GET",
-		Path:        strings.Join([]string{root, "agent"}, "/"),
-		HandlerFunc: agentHandler,
+		Path:        strings.Join([]string{root, "node"}, "/"),
+		HandlerFunc: nodeHandler,
 	},
+}
 
+var agentRoutes = []Route{
 	// Containers and apps endpoints,e.g. /api/v0/containers...
 	Route{
 		Name:        "containers",

--- a/producers/interface.go
+++ b/producers/interface.go
@@ -21,8 +21,8 @@ var (
 	MetricNamespaceSep = "."
 	// ContainerMetricPrefix defines the prefix of container-level metrics
 	ContainerMetricPrefix = strings.Join([]string{"dcos", "metrics", "container"}, MetricNamespaceSep)
-	// AgentMetricPrefix defines the prefix of agent-level metrics
-	AgentMetricPrefix = strings.Join([]string{"dcos", "metrics", "agent"}, MetricNamespaceSep)
+	// NodeMetricPrefix defines the prefix of node-level metrics
+	NodeMetricPrefix = strings.Join([]string{"dcos", "metrics", "node"}, MetricNamespaceSep)
 	// AppMetricPrefix defines the prefix of app-level metrics
 	AppMetricPrefix = strings.Join([]string{"dcos", "metrics", "app"}, MetricNamespaceSep)
 )
@@ -62,8 +62,8 @@ type Datapoint struct {
 
 // Dimensions are metadata about the metrics contained in a given MetricsMessage.
 type Dimensions struct {
-	AgentID            string            `json:"agent_id"`
-	ClusterID          string            `json:"cluster_id"`
+	MesosID            string            `json:"mesos_id"`
+	ClusterID          string            `json:"cluster_id,omitempty"`
 	ContainerID        string            `json:"container_id,omitempty"`
 	ExecutorID         string            `json:"executor_id,omitempty"`
 	FrameworkName      string            `json:"framework_name,omitempty"`


### PR DESCRIPTION
 This PR updates the producer and collector code to run node level metrics on any DC/OS role:    
- Agent -> DCOSHost
- AgentID -> MesosID
- Query node level metrics on all DC/OS roles
- Load different routes based on DC/OS role
- Explicit loggers for each collector and producer
