### PR TITLE
Use a generalized http.Client

### DIFF
--- a/collector/config.go
+++ b/collector/config.go
@@ -14,6 +14,8 @@
 
 package collector
 
+import "net/http"
+
 // MasterConfig contains configuration options relevant to metrics collection
 // from a DC/OS (Mesos) master.
 type MasterConfig struct {
@@ -23,5 +25,6 @@ type MasterConfig struct {
 // AgentConfig contains configuration options relevant to metrics collection
 // from a DC/OS (Mesos) agent.
 type AgentConfig struct {
-	Port int `yaml:"port,omitempty"`
+	Port       int `yaml:"port,omitempty"`
+	HTTPClient *http.Client
 }

--- a/collector/node_collector.go
+++ b/collector/node_collector.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"text/template"
@@ -33,6 +34,9 @@ var nodeColLog = log.WithFields(log.Fields{
 
 // Agent defines the structure of the agent metrics poller and any configuration
 // that might be required to run it.
+// This entire struct should be the AgentCollectorConfig
+// TODO(malnick) decompose configs so this is
+// all set in main
 type DCOSHost struct {
 	Port        int
 	PollPeriod  time.Duration
@@ -42,6 +46,7 @@ type DCOSHost struct {
 	MesosID     string
 	ClusterID   string
 	Hostname    string
+	HTTPClient  *http.Client
 }
 
 // metricsMeta is a high-level struct that contains data structures with the
@@ -66,6 +71,7 @@ func NewDCOSHost(
 	clusterID string,
 	port int,
 	pollPeriod time.Duration,
+	httpClient *http.Client,
 	metricsChan chan<- producers.MetricsMessage) (DCOSHost, error) {
 	h := DCOSHost{}
 
@@ -84,6 +90,7 @@ func NewDCOSHost(
 	h.MesosID = mesosID
 	h.ClusterID = clusterID
 	h.Hostname = ipAddress
+	h.HTTPClient = httpClient
 
 	return h, nil
 }

--- a/collector/node_collector_test.go
+++ b/collector/node_collector_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	httpHelpers "github.com/dcos/dcos-metrics/http_helpers"
 	"github.com/dcos/dcos-metrics/producers"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -67,6 +68,11 @@ func TestBuildDatapoints(t *testing.T) {
 }
 
 func TestNewDCOSHost(t *testing.T) {
+	testClient, err := httpHelpers.NewMetricsClient("", "")
+	if err != nil {
+		t.Error("Error retreiving HTTP Client:", err)
+	}
+
 	Convey("When establishing a new DCOSHost object", t, func() {
 		Convey("Should return an error when given an improper port", func() {
 			_, err := NewDCOSHost(
@@ -76,6 +82,7 @@ func TestNewDCOSHost(t *testing.T) {
 				"test_cluster-id",
 				1023,
 				60,
+				testClient,
 				make(chan<- producers.MetricsMessage))
 			So(err, ShouldNotBeNil)
 		})
@@ -88,6 +95,7 @@ func TestNewDCOSHost(t *testing.T) {
 				"test_cluster-id",
 				1024,
 				0,
+				testClient,
 				make(chan<- producers.MetricsMessage))
 			So(err, ShouldNotBeNil)
 		})
@@ -100,6 +108,7 @@ func TestNewDCOSHost(t *testing.T) {
 				"test_cluster-id",
 				10000,
 				60,
+				testClient,
 				make(chan<- producers.MetricsMessage))
 			So(a, ShouldHaveSameTypeAs, DCOSHost{})
 			So(err, ShouldBeNil)
@@ -108,6 +117,11 @@ func TestNewDCOSHost(t *testing.T) {
 }
 
 func TestTransform(t *testing.T) {
+	testClient, err := httpHelpers.NewMetricsClient("", "")
+	if err != nil {
+		t.Error("Error retreiving HTTP Client:", err)
+	}
+
 	Convey("When transforming agent metrics to fit producers.MetricsMessage", t, func() {
 		// bogus port and IP address here; no HTTP client in a.transform()
 		h, _ := NewDCOSHost(
@@ -117,6 +131,7 @@ func TestTransform(t *testing.T) {
 			"test_cluster-id",
 			9000,
 			60,
+			testClient,
 			make(chan<- producers.MetricsMessage))
 
 		// The mocks in this test file are bytearrays so that they can be used

--- a/dcos-metrics.go
+++ b/dcos-metrics.go
@@ -84,7 +84,9 @@ func main() {
 		cfg.MesosID,
 		cfg.ClusterID,
 		cfg.Collector.AgentConfig.Port,
-		time.Duration(cfg.Collector.PollingPeriod)*time.Second, nodeCollectorChan)
+		time.Duration(cfg.Collector.PollingPeriod)*time.Second,
+		cfg.Collector.AgentConfig.HTTPClient,
+		nodeCollectorChan)
 
 	if err != nil {
 		log.Fatal(err.Error())

--- a/examples/statsd-emitter/example-output.json
+++ b/examples/statsd-emitter/example-output.json
@@ -1,0 +1,22 @@
+
+{
+  "datapoints": [
+    {
+      "name": "statsd_tester.time.uptime",
+      "value": 1479588678444,
+      "unit": "0",
+      "timestamp": "2016-11-19 20:51:19.180548691 +0000 UTC"
+    }
+  ],
+  "dimensions": {
+    "mesos_id": "2a5a652b-5e3d-4df2-9ba5-10a0211ecc07-S1",
+    "container_id": "c3271342-f233-460f-a1b1-759ca0fc5059",
+    "executor_id": "emitter.1638c5cd-ae98-11e6-b63d-7228834ce844",
+    "framework_id": "2a5a652b-5e3d-4df2-9ba5-10a0211ecc07-0000",
+    "hostname": "10.0.0.123",
+    "labels": {
+      "test_tag_key": "test_tag_value"
+    }
+  }
+}
+

--- a/http_helpers/http_helpers.go
+++ b/http_helpers/http_helpers.go
@@ -1,4 +1,4 @@
-package main
+package http_helpers
 
 import (
 	"crypto/tls"
@@ -55,7 +55,10 @@ func getTransport(caCertificatePath string) (*http.Transport, error) {
 	return tr, nil
 }
 
-func getClient(caCertificatePath string, iamConfigPath string) (*http.Client, error) {
+// GetMetricsClient returns a client with a transport using dcos-go/jwt/transport for
+// secure communications if a IAM configuration is present. It uses a verified cert if
+// present and skips verification if not present.
+func NewMetricsClient(caCertificatePath string, iamConfigPath string) (*http.Client, error) {
 	client := &http.Client{}
 	tr, err := getTransport(caCertificatePath)
 	if err != nil {


### PR DESCRIPTION
- [ ] Refactor http_client to only have a single Fetch() method which accepts a http.Client
- [ ] Set client in main config using the generalized `http_helpers.NewMetricsClient()`
- [ ] Put http_helpers.go in their own package so we can leverage it in other sub packages