### PR TITLE
Degrade if cert path is not found

### DIFF
--- a/util/http/helpers/helpers.go
+++ b/util/http/helpers/helpers.go
@@ -55,7 +55,12 @@ func getTransport(caCertificatePath string) (*http.Transport, error) {
 		log.Infof("Loading CA cert: %s", caCertificatePath)
 		caPool, err := loadCAPool(caCertificatePath)
 		if err != nil {
-			return tr, err
+			log.Errorf("Error loading CA: %s", err.Error())
+			log.Warn("Skipping certificate verification.")
+			tr.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+			return tr, nil
 		}
 
 		tr.TLSClientConfig = &tls.Config{


### PR DESCRIPTION
If a CA cert is not present but path is given, we need to degrade to no cert verification. The method proposed in this commit will also make it so if cert verification fails, we degrade to no cert verification. I am not sure if this is the best way to go about this. We might want to consider a helper method that attempts loading the cert from a path in another method, and degrading only if the certificate path that is given does not exist, and not if the cert verification or other failures that might occur in the load CA cert method happen.