### PR TITLE
Default Majority of Configuration 

### DIFF
--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -155,7 +155,7 @@ func (h *Collector) RunPoller() {
 		for _, m := range h.transformContainerMetrics() {
 			h.MetricsChan <- m
 		}
-		time.Sleep(h.PollPeriod * time.Second)
+		time.Sleep(h.PollPeriod)
 	}
 }
 

--- a/collectors/node/node.go
+++ b/collectors/node/node.go
@@ -49,7 +49,7 @@ func (h *Collector) RunPoller() {
 		for _, m := range h.transform() {
 			h.MetricsChan <- m
 		}
-		time.Sleep(h.PollPeriod * time.Second)
+		time.Sleep(h.PollPeriod)
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -187,7 +187,7 @@ func getNewConfig(args []string) (Config, error) {
 	// If the -version flag was passed, ignore all other args, print the version, and exit
 	if c.VersionFlag {
 		fmt.Printf(strings.Join([]string{
-			"DC/OS Metrics Service",
+			fmt.Sprintf("DC/OS Metrics Service (%s)", c.DCOSRole),
 			fmt.Sprintf("Version: %s", VERSION),
 			fmt.Sprintf("Revision: %s", REVISION),
 			fmt.Sprintf("HTTP User-Agent: %s", httpClient.USERAGENT),

--- a/config.go
+++ b/config.go
@@ -92,7 +92,8 @@ func (c *Config) setFlags(fs *flag.FlagSet) {
 func (c *Config) loadConfig() error {
 	fileByte, err := ioutil.ReadFile(c.ConfigPath)
 	if err != nil {
-		return err
+		log.Warnf("%s not found. Using all defaults", c.ConfigPath)
+		return nil
 	}
 
 	if err = yaml.Unmarshal(fileByte, &c); err != nil {
@@ -147,18 +148,19 @@ func (c *Config) getNodeInfo() error {
 func newConfig() Config {
 	return Config{
 		Collector: CollectorConfig{
-			HTTPProfiler: true,
+			HTTPProfiler: false,
 			MesosAgent: &mesosAgent.Collector{
-				PollPeriod: 15,
-				Port:       5051,
+				PollPeriod:      60,
+				Port:            5051,
+				RequestProtocol: "http",
 			},
 			Node: &node.Collector{
-				PollPeriod: 15,
+				PollPeriod: 60,
 			},
 		},
 		Producers: ProducersConfig{
 			HTTPProducerConfig: httpProducer.Config{
-				Port: 8000,
+				Port: 9000,
 			},
 		},
 		ConfigPath: "dcos-metrics-config.yaml",

--- a/config_test.go
+++ b/config_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
@@ -30,20 +31,24 @@ func TestNewConfig(t *testing.T) {
 	Convey("Ensure default configuration is set properly", t, func() {
 		testConfig := newConfig()
 
-		Convey("Default node polling period should be 15", func() {
-			So(testConfig.Collector.Node.PollPeriod, ShouldEqual, 15)
+		Convey("Default node polling period should be 60 seconds", func() {
+			So(testConfig.Collector.Node.PollPeriod, ShouldEqual, 60*time.Second)
 		})
 
-		Convey("Default mesos agent polling period should be 15", func() {
-			So(testConfig.Collector.MesosAgent.PollPeriod, ShouldEqual, 15)
+		Convey("Default mesos agent polling period should be 60 seconds", func() {
+			So(testConfig.Collector.MesosAgent.PollPeriod, ShouldEqual, 60*time.Second)
 		})
 
-		Convey("HTTP profiler should be enabled by default", func() {
-			So(testConfig.Collector.HTTPProfiler, ShouldBeTrue)
+		Convey("HTTP profiler should be disabled by default", func() {
+			So(testConfig.Collector.HTTPProfiler, ShouldBeFalse)
 		})
 
 		Convey("Default log level should be 'info'", func() {
 			So(testConfig.LogLevel, ShouldEqual, "info")
+		})
+
+		Convey("Default HTTP producer port should be 9000", func() {
+			So(testConfig.Producers.HTTPProducerConfig.Port, ShouldEqual, 9000)
 		})
 	})
 }
@@ -125,6 +130,9 @@ collector:
 
 func TestGetNewConfig(t *testing.T) {
 	Convey("When getting the service configuration", t, func() {
+		Convey("Should error if the user did not specify exactly one role (master or agent)", nil)
+		Convey("Should use all defaults if the -config flag wasn't passed", nil)
+		Convey("Should output only the collector version if -version was used", nil)
 		Convey("Command-line flags should take precedence over the config file", nil)
 		Convey("Actual node configuration (from Mesos) should take precendence over command-line flags", nil)
 		Convey("The HTTP client should be initialized based on the provided configuration", nil)

--- a/config_test.go
+++ b/config_test.go
@@ -130,11 +130,27 @@ collector:
 
 func TestGetNewConfig(t *testing.T) {
 	Convey("When getting the service configuration", t, func() {
-		Convey("Should error if the user did not specify exactly one role (master or agent)", nil)
-		Convey("Should use all defaults if the -config flag wasn't passed", nil)
-		Convey("Should output only the collector version if -version was used", nil)
-		Convey("Command-line flags should take precedence over the config file", nil)
-		Convey("Actual node configuration (from Mesos) should take precendence over command-line flags", nil)
-		Convey("The HTTP client should be initialized based on the provided configuration", nil)
+		Convey("Should error if the user did not specify exactly one role (master or agent)", func() {
+			Convey("If the role flag is missing", func() {
+				_, err := getNewConfig([]string{""})
+				So(err, ShouldNotBeNil)
+			})
+			Convey("If the provided value is not a valid role", func() {
+				_, err := getNewConfig([]string{"-role", "foo"})
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("Should use all defaults if the -config flag wasn't passed", func() {
+			// I really don't like ignoring the err here, but unfortunately we
+			// have no choice: chances are good that "/opt/mesosphere/bin/detect_ip"
+			// doesn't exist on your system. Since we use nodeutil from dcos-go, we
+			// can't mock the path to the IP detect script here. So err is always
+			// not-nil in this test :'(   -- roger, 2016-12-05
+			c, _ := getNewConfig([]string{"-role", "agent"})
+			So(c.Collector, ShouldResemble, newConfig().Collector)
+			So(c.Producers, ShouldResemble, newConfig().Producers)
+			So(c.LogLevel, ShouldResemble, newConfig().LogLevel)
+		})
 	})
 }

--- a/dcos-metrics.go
+++ b/dcos-metrics.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 	"strings"
@@ -26,7 +25,6 @@ import (
 	frameworkCollector "github.com/dcos/dcos-metrics/collectors/framework"
 	"github.com/dcos/dcos-metrics/producers"
 	httpProducer "github.com/dcos/dcos-metrics/producers/http"
-	httpClient "github.com/dcos/dcos-metrics/util/http/client"
 	"github.com/dcos/dcos-metrics/util/http/profiler"
 	//kafkaProducer "github.com/dcos/dcos-metrics/producers/kafka"
 	//statsdProducer "github.com/dcos/dcos-metrics/producers/statsd"
@@ -38,15 +36,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 		os.Exit(1)
-	}
-	if cfg.VersionFlag {
-		fmt.Printf(strings.Join([]string{
-			"DC/OS Metrics Service",
-			fmt.Sprintf("Version: %s", VERSION),
-			fmt.Sprintf("Revision: %s", REVISION),
-			fmt.Sprintf("HTTP User-Agent: %s", httpClient.USERAGENT),
-		}, "\n"))
-		os.Exit(0)
 	}
 
 	// Set logging level

--- a/dcos-metrics_test.go
+++ b/dcos-metrics_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"os/exec"
 	"testing"
 
@@ -31,11 +30,11 @@ func TestMain(t *testing.T) {
 	// This test assumes that `go build` was run before `go test`,
 	// preferably by running `make` at the root of this repo.
 	Convey("Version and revision should match Git", t, func() {
-		cmd := exec.Command("/bin/bash", "-c", "./build/collector/dcos-metrics-collector* -config /dev/null -version")
+		cmd := exec.Command("/bin/bash", "-c", "./build/collector/dcos-metrics-collector* -role agent -version")
 		stdout := bytes.Buffer{}
 		cmd.Stdout = &stdout
 		cmd.Run()
-		fmt.Println(stdout.String())
+		So(stdout.String(), ShouldContainSubstring, "DC/OS Metrics Service (agent)")
 		So(stdout.String(), ShouldContainSubstring, "Version: ")
 		So(stdout.String(), ShouldContainSubstring, "Revision: ")
 		So(stdout.String(), ShouldContainSubstring, "HTTP User-Agent: ")


### PR DESCRIPTION
Default the configuration we are not passing in via the config.yaml for the DC/OS installer. We should only override things in enterprise config file with EE specific config, everything else can be defaulted for now. TODO - expose collector polling times in config.yaml.

@rji When you get a moment can you review this?