### PR TITLE
Added INJECT_TAG_X_Y environment variables

### DIFF
--- a/consumers/metrics-consumer-common/src/main/java/com/mesosphere/metrics/consumer/common/ConsumerRunner.java
+++ b/consumers/metrics-consumer-common/src/main/java/com/mesosphere/metrics/consumer/common/ConsumerRunner.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.avro.AvroRuntimeException;
@@ -110,6 +111,7 @@ public class ConsumerRunner {
                 metricList = dataFileStream.next(metricList);
 
                 if (isFrameworkMatch(consumerConfig.frameworkWhitelist, metricList)) {
+                  metricList = addInjectedTags(metricList, consumerConfig);
                   if (consumerConfig.printRecords) {
                     LOGGER.info("Record: {}", metricList);
                   }
@@ -219,6 +221,16 @@ public class ConsumerRunner {
         }
       }
       return null;
+    }
+
+    private static MetricList addInjectedTags(MetricList metricList,
+                                              ClientConfigs.ConsumerConfig consumerConfig) {
+      List<Tag> tags = metricList.getTags();
+      for (Entry<String, Object> entry : consumerConfig.injectedTags.entrySet()) {
+        tags.add(new Tag(entry.getKey(), (String) entry.getValue()));
+      }
+      metricList.put("tags", tags);
+      return metricList;
     }
   }
 

--- a/docs/CONSUMERS.md
+++ b/docs/CONSUMERS.md
@@ -54,6 +54,8 @@ Each consumer implementation shares the following settings from `metrics-consume
 
 In addition to the above values, any configuration variables defined by the Kafka Consumer client library can be configured via the environment. Any values of the form `KAFKA_OVERRIDE_X_Y` will be given to the Kafka library in the form `x.y`. For example, the value `KAFKA_OVERRIDE_BOOTSTRAP_SERVERS=broker1:1234,broker2:2345` will be given to Kafka as `bootstrap.servers=broker1:1234,broker2:2345`. This allows full customization of the underlying Kafka consumer.
 
+You may also inject arbitrary tags via the environment. Any values of the form `INJECT_TAG_X_Y` will be output as a tag with key `x.y`. For example, the value `INJECT_TAG_CLUSTER_TYPE=dcos` will be output as `cluster.type:dcos`.
+
 ### Graphite Consumer
 
 Sends data to a Graphite server.


### PR DESCRIPTION
Added INJECT_TAG_X_Y environment variables which allow users to inject arbitrary tags via the config.

Example: I have a Datadog instance which monitors multiple clusters. This patch allows me to add my own "cluster.name:my-dcos-cluster" tag to distinguish between different clusters, by setting INJECT_TAG_CLUSTER_NAME=my-dcos-cluster.

cc @nickbp for review