### PR TITLE
Node collector: unit values, nodeMetricPoller interface refactor 

### DIFF
--- a/collectors/node/cpu.go
+++ b/collectors/node/cpu.go
@@ -1,0 +1,152 @@
+package node
+
+import (
+	"math"
+	"sync"
+
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/shirou/gopsutil/cpu"
+)
+
+type cpuCoresMetric struct {
+	cpuCores  int32
+	cpuTotal  float64
+	cpuUser   float64
+	cpuSystem float64
+	cpuIdle   float64
+	cpuWait   float64
+	timestamp string
+}
+
+func (m *cpuCoresMetric) poll() error {
+	ts := thisTime()
+	hi, err := getNumCores()
+	if err != nil {
+		return err
+	}
+
+	cpuStatePcts := calculatePcts(getCPUTimes())
+
+	m.cpuCores = hi
+	m.timestamp = ts
+	m.cpuTotal = cpuStatePcts.User + cpuStatePcts.System
+	m.cpuUser = cpuStatePcts.User
+	m.cpuSystem = cpuStatePcts.System
+	m.cpuIdle = cpuStatePcts.Idle
+	m.cpuWait = cpuStatePcts.Iowait
+
+	return nil
+}
+
+func (m *cpuCoresMetric) addDatapoints(nc *nodeCollector) error {
+	cpuDps := []producers.Datapoint{
+		producers.Datapoint{
+			Name:      CPU_CORES,
+			Unit:      COUNT,
+			Value:     m.cpuCores,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      CPU_TOTAL,
+			Unit:      COUNT,
+			Value:     m.cpuTotal,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      CPU_USER,
+			Unit:      COUNT,
+			Value:     m.cpuUser,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      CPU_SYSTEM,
+			Unit:      COUNT,
+			Value:     m.cpuSystem,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      CPU_IDLE,
+			Unit:      COUNT,
+			Value:     m.cpuIdle,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      CPU_WAIT,
+			Unit:      COUNT,
+			Value:     m.cpuWait,
+			Timestamp: m.timestamp,
+		},
+	}
+
+	for _, dp := range cpuDps {
+		nc.datapoints = append(nc.datapoints, dp)
+	}
+
+	return nil
+}
+
+// -- helpers
+func getNumCores() (int32, error) {
+	cores := int32(0)
+	cpus, err := cpu.Info()
+	if err != nil {
+		return cores, err
+	}
+	for _, c := range cpus {
+		cores += c.Cores
+	}
+	return cores, nil
+}
+
+/* CPU Helper Methods */
+type lastCPUTimes struct {
+	sync.Mutex
+	times cpu.TimesStat
+}
+
+var lastCPU lastCPUTimes
+
+func init() {
+	t, _ := cpu.Times(false) // get totals, not per-cpu stats
+	lastCPU.Lock()
+	lastCPU.times = t[0]
+	lastCPU.Unlock()
+}
+
+func getCPUTimes() (cpu.TimesStat, cpu.TimesStat) {
+	currentTimes, _ := cpu.Times(false) // get totals, not per-cpu stats
+	lastTimes := lastCPU.times
+
+	lastCPU.Lock()
+	lastCPU.times = currentTimes[0] // update lastTimes to the currentTimes
+	lastCPU.Unlock()
+
+	return currentTimes[0], lastTimes
+}
+
+// calculatePct returns the percent utilization for CPU states. 100.00 => 100.00%
+func calculatePcts(lastTimes cpu.TimesStat, curTimes cpu.TimesStat) cpu.TimesStat {
+	totalDelta := curTimes.Total() - lastTimes.Total()
+	if totalDelta == 0 {
+		totalDelta = 1 // can't divide by zero
+	}
+	return cpu.TimesStat{
+		User:      round(math.Dim(curTimes.User, lastTimes.User) / totalDelta * 100),
+		System:    round(math.Dim(curTimes.System, lastTimes.System) / totalDelta * 100),
+		Idle:      round(math.Dim(curTimes.Idle, lastTimes.Idle) / totalDelta * 100),
+		Nice:      round(math.Dim(curTimes.Nice, lastTimes.Nice) / totalDelta * 100),
+		Iowait:    round(math.Dim(curTimes.Iowait, lastTimes.Iowait) / totalDelta * 100),
+		Irq:       round(math.Dim(curTimes.Irq, lastTimes.Irq) / totalDelta * 100),
+		Softirq:   round(math.Dim(curTimes.Softirq, lastTimes.Softirq) / totalDelta * 100),
+		Steal:     round(math.Dim(curTimes.Steal, lastTimes.Steal) / totalDelta * 100),
+		Guest:     round(math.Dim(curTimes.Guest, lastTimes.Guest) / totalDelta * 100),
+		GuestNice: round(math.Dim(curTimes.GuestNice, lastTimes.GuestNice) / totalDelta * 100),
+		Stolen:    round(math.Dim(curTimes.Stolen, lastTimes.Stolen) / totalDelta * 100),
+	}
+}
+
+// Helper function for rounding to two decimal places
+func round(f float64) float64 {
+	shift := math.Pow(10, float64(2))
+	return math.Floor(f*shift+.5) / shift
+}

--- a/collectors/node/cpu.go
+++ b/collectors/node/cpu.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/collectors/node/cpu.go
+++ b/collectors/node/cpu.go
@@ -57,8 +57,8 @@ func (m *cpuCoresMetric) poll() error {
 	return nil
 }
 
-func (m *cpuCoresMetric) addDatapoints(nc *nodeCollector) error {
-	cpuDps := []producers.Datapoint{
+func (m *cpuCoresMetric) getDatapoints() ([]producers.Datapoint, error) {
+	return []producers.Datapoint{
 		producers.Datapoint{
 			Name:      CPU_CORES,
 			Unit:      COUNT,
@@ -95,10 +95,7 @@ func (m *cpuCoresMetric) addDatapoints(nc *nodeCollector) error {
 			Value:     m.cpuWait,
 			Timestamp: m.timestamp,
 		},
-	}
-
-	nc.datapoints = append(nc.datapoints, cpuDps...)
-	return nil
+	}, nil
 }
 
 // -- helpers

--- a/collectors/node/cpu_test.go
+++ b/collectors/node/cpu_test.go
@@ -1,0 +1,31 @@
+package node
+
+import "testing"
+
+var (
+	mockCpuMetric = cpuCoresMetric{
+		cpuCores:  4,
+		cpuTotal:  float64(12.50),
+		cpuUser:   float64(9.60),
+		cpuSystem: float64(2.90),
+		cpuIdle:   float64(87.40),
+		cpuWait:   float64(0.10),
+		timestamp: "2009-11-10T23:00:00Z",
+	}
+)
+
+func TestCPUAddDatapoints(t *testing.T) {
+
+	mockNc := nodeCollector{}
+
+	err := mockCpuMetric.addDatapoints(&mockNc)
+
+	if err != nil {
+		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
+	}
+
+	if len(mockNc.datapoints) != 6 {
+		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+	}
+
+}

--- a/collectors/node/cpu_test.go
+++ b/collectors/node/cpu_test.go
@@ -35,17 +35,17 @@ var (
 	}
 )
 
-func TestCPUAddDatapoints(t *testing.T) {
+func TestCPUGetDatapoints(t *testing.T) {
 
 	mockNc := nodeCollector{}
 
-	err := mockCpuMetric.addDatapoints(&mockNc)
+	dps, err := mockCpuMetric.getDatapoints()
 
 	if err != nil {
 		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
 	}
 
-	if len(mockNc.datapoints) != 6 {
+	if len(dps) != 6 {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 
@@ -135,7 +135,10 @@ func TestGetCPUTimes(t *testing.T) {
 	Convey("When getting CPU times", t, func() {
 		Convey("Should return both the current times and last times (so that percentages can be calculated)", func() {
 			time.Sleep(1 * time.Second)
-			cur, last := getCPUTimes()
+			cur, last, err := getCPUTimes()
+			if err != nil {
+				t.Fatal(err)
+			}
 			So(cur.User, ShouldBeGreaterThan, last.User)
 			So(cur.Idle, ShouldBeGreaterThan, last.Idle)
 		})

--- a/collectors/node/cpu_test.go
+++ b/collectors/node/cpu_test.go
@@ -1,6 +1,27 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/cpu"
+	. "github.com/smartystreets/goconvey/convey"
+)
 
 var (
 	mockCpuMetric = cpuCoresMetric{
@@ -28,4 +49,95 @@ func TestCPUAddDatapoints(t *testing.T) {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 
+}
+
+func TestCalculatePcts(t *testing.T) {
+	lastTimes := cpu.TimesStat{
+		CPU:       "cpu-total",
+		User:      20564.8,
+		System:    5355.2,
+		Idle:      3866.2,
+		Nice:      1141.0,
+		Iowait:    161.4,
+		Irq:       0.0,
+		Softirq:   138.8,
+		Steal:     0.0,
+		Guest:     0.0,
+		GuestNice: 0.0,
+		Stolen:    0.0,
+	}
+	currentTimes := cpu.TimesStat{
+		CPU:       "cpu-total",
+		User:      20675.6,
+		System:    5388.1,
+		Idle:      39568.8,
+		Nice:      1141.0,
+		Iowait:    164.5,
+		Irq:       0.0,
+		Softirq:   139.2,
+		Steal:     0.0,
+		Guest:     0.0,
+		GuestNice: 0.0,
+		Stolen:    0.0,
+	}
+
+	Convey("When calculating CPU state percentages", t, func() {
+		pcts := calculatePcts(lastTimes, currentTimes)
+		Convey("Percentages should be calculated to two decimal places", func() {
+			So(pcts.User, ShouldEqual, 0.31)
+			So(pcts.System, ShouldEqual, 0.09)
+			So(pcts.Idle, ShouldEqual, 99.59)
+			So(pcts.Iowait, ShouldEqual, 0.01)
+		})
+		Convey("No percentages should be negative", func() {
+			v := reflect.ValueOf(pcts)
+			for i := 0; i < v.NumField(); i++ {
+				if v.Field(i).Kind() == reflect.String {
+					continue
+				}
+				So(v.Field(i).Interface(), ShouldBeGreaterThanOrEqualTo, 0)
+			}
+		})
+	})
+}
+
+func TestRound(t *testing.T) {
+	Convey("When rounding float64 values to two decimal places", t, func() {
+		Convey("Should work on all numbers", func() {
+			testCases := []struct {
+				input    float64
+				expected float64
+			}{
+				{-123.456, -123.46},
+				{123.456, 123.46},
+				{0, 0.00},
+				{-1, -1.00},
+				{100.00000, 100.00},
+				{100, 100.00},
+			}
+
+			for _, tc := range testCases {
+				So(round(tc.input), ShouldEqual, tc.expected)
+			}
+		})
+	})
+}
+
+func TestInit(t *testing.T) {
+	Convey("When initializing the node metrics collector", t, func() {
+		Convey("Should automatically set lastCPU times", func() {
+			So(lastCPU.times.CPU, ShouldNotEqual, "")
+		})
+	})
+}
+
+func TestGetCPUTimes(t *testing.T) {
+	Convey("When getting CPU times", t, func() {
+		Convey("Should return both the current times and last times (so that percentages can be calculated)", func() {
+			time.Sleep(1 * time.Second)
+			cur, last := getCPUTimes()
+			So(cur.User, ShouldBeGreaterThan, last.User)
+			So(cur.Idle, ShouldBeGreaterThan, last.Idle)
+		})
+	})
 }

--- a/collectors/node/filesystem.go
+++ b/collectors/node/filesystem.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/collectors/node/filesystem.go
+++ b/collectors/node/filesystem.go
@@ -1,0 +1,115 @@
+package node
+
+import (
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/shirou/gopsutil/disk"
+)
+
+type filesystemMetrics struct {
+	fsMetrics []filesystemMetric
+}
+
+type filesystemMetric struct {
+	path        string
+	capTotal    uint64
+	capUsed     uint64
+	capFree     uint64
+	inodesTotal uint64
+	inodesUsed  uint64
+	inodesFree  uint64
+	timestamp   string
+}
+
+func (m *filesystemMetrics) poll() error {
+	f := []filesystemMetric{}
+
+	ts := thisTime()
+	parts, err := disk.Partitions(false) // only phsysical partitions
+	if err != nil {
+		return err
+	}
+
+	for _, part := range parts {
+		usage, err := disk.Usage(part.Mountpoint)
+		if err != nil {
+			return err
+		}
+
+		f = append(f, filesystemMetric{
+			path:        usage.Path,
+			capTotal:    usage.Total,
+			capUsed:     usage.Used,
+			capFree:     usage.Free,
+			inodesTotal: usage.InodesTotal,
+			inodesUsed:  usage.InodesUsed,
+			inodesFree:  usage.InodesFree,
+			timestamp:   ts,
+		})
+	}
+
+	m.fsMetrics = f
+	return nil
+}
+
+func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
+	/* Enumerate each filesystem found and add a datapoint object contining the
+	capacity and inode metrics plus a tag denoting the filesystem
+	path from which these came */
+	for _, fs := range m.fsMetrics {
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      FS_CAP_TOTAL,
+			Unit:      BYTES,
+			Value:     fs.capTotal,
+			Timestamp: fs.timestamp,
+			Tags: map[string]string{
+				"path": fs.path,
+			},
+		})
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      FS_CAP_USED,
+			Unit:      BYTES,
+			Value:     fs.capUsed,
+			Timestamp: fs.timestamp,
+			Tags: map[string]string{
+				"path": fs.path,
+			},
+		})
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      FS_CAP_FREE,
+			Unit:      BYTES,
+			Value:     fs.capFree,
+			Timestamp: fs.timestamp,
+			Tags: map[string]string{
+				"path": fs.path,
+			},
+		})
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      FS_INODE_TOTAL,
+			Unit:      COUNT,
+			Value:     fs.inodesTotal,
+			Timestamp: fs.timestamp,
+			Tags: map[string]string{
+				"path": fs.path,
+			},
+		})
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      FS_INODE_USED,
+			Unit:      COUNT,
+			Value:     fs.inodesUsed,
+			Timestamp: fs.timestamp,
+			Tags: map[string]string{
+				"path": fs.path,
+			},
+		})
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      FS_INODE_FREE,
+			Unit:      COUNT,
+			Value:     fs.inodesFree,
+			Timestamp: fs.timestamp,
+			Tags: map[string]string{
+				"path": fs.path,
+			},
+		})
+	}
+	return nil
+}

--- a/collectors/node/filesystem.go
+++ b/collectors/node/filesystem.go
@@ -65,12 +65,13 @@ func (m *filesystemMetrics) poll() error {
 	return nil
 }
 
-func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
+func (m *filesystemMetrics) getDatapoints() ([]producers.Datapoint, error) {
+	var fsDps []producers.Datapoint
 	/* Enumerate each filesystem found and add a datapoint object contining the
 	capacity and inode metrics plus a tag denoting the filesystem
 	path from which these came */
 	for _, fs := range m.fsMetrics {
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		fsDps = append(fsDps, producers.Datapoint{
 			Name:      FS_CAP_TOTAL,
 			Unit:      BYTES,
 			Value:     fs.capTotal,
@@ -79,7 +80,7 @@ func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
 				"path": fs.path,
 			},
 		})
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		fsDps = append(fsDps, producers.Datapoint{
 			Name:      FS_CAP_USED,
 			Unit:      BYTES,
 			Value:     fs.capUsed,
@@ -88,7 +89,7 @@ func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
 				"path": fs.path,
 			},
 		})
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		fsDps = append(fsDps, producers.Datapoint{
 			Name:      FS_CAP_FREE,
 			Unit:      BYTES,
 			Value:     fs.capFree,
@@ -97,7 +98,7 @@ func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
 				"path": fs.path,
 			},
 		})
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		fsDps = append(fsDps, producers.Datapoint{
 			Name:      FS_INODE_TOTAL,
 			Unit:      COUNT,
 			Value:     fs.inodesTotal,
@@ -106,7 +107,7 @@ func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
 				"path": fs.path,
 			},
 		})
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		fsDps = append(fsDps, producers.Datapoint{
 			Name:      FS_INODE_USED,
 			Unit:      COUNT,
 			Value:     fs.inodesUsed,
@@ -115,7 +116,7 @@ func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
 				"path": fs.path,
 			},
 		})
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		fsDps = append(fsDps, producers.Datapoint{
 			Name:      FS_INODE_FREE,
 			Unit:      COUNT,
 			Value:     fs.inodesFree,
@@ -125,5 +126,5 @@ func (m *filesystemMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 	}
-	return nil
+	return fsDps, nil
 }

--- a/collectors/node/filesystem_test.go
+++ b/collectors/node/filesystem_test.go
@@ -1,0 +1,43 @@
+package node
+
+import "testing"
+
+var mockFS = filesystemMetrics{
+	fsMetrics: []filesystemMetric{
+		filesystemMetric{
+			path:        "/",
+			capTotal:    uint64(449660412 * 1024),
+			capUsed:     uint64(25819220 * 1024),
+			capFree:     uint64(423841192 * 1024),
+			inodesTotal: uint64(458961 * 1024),
+			inodesUsed:  uint64(191925 * 1024),
+			inodesFree:  uint64(267036 * 1024),
+			timestamp:   "2009-11-10T23:00:00Z",
+		},
+		filesystemMetric{
+			path:        "/boot",
+			capTotal:    uint64(449660412 * 1024),
+			capUsed:     uint64(25819220 * 1024),
+			capFree:     uint64(423841192 * 1024),
+			inodesTotal: uint64(458961 * 1024),
+			inodesUsed:  uint64(191925 * 1024),
+			inodesFree:  uint64(267036 * 1024),
+			timestamp:   "2009-11-10T23:00:00Z",
+		},
+	},
+}
+
+func TestFilesystemAddDatapoints(t *testing.T) {
+	mockNc := nodeCollector{}
+
+	err := mockFS.addDatapoints(&mockNc)
+
+	if err != nil {
+		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
+	}
+
+	if len(mockNc.datapoints) != 12 {
+		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+	}
+
+}

--- a/collectors/node/filesystem_test.go
+++ b/collectors/node/filesystem_test.go
@@ -44,13 +44,13 @@ var mockFS = filesystemMetrics{
 func TestFilesystemAddDatapoints(t *testing.T) {
 	mockNc := nodeCollector{}
 
-	err := mockFS.addDatapoints(&mockNc)
+	dps, err := mockFS.getDatapoints()
 
 	if err != nil {
 		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
 	}
 
-	if len(mockNc.datapoints) != 12 {
+	if len(dps) != 12 {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 

--- a/collectors/node/filesystem_test.go
+++ b/collectors/node/filesystem_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import "testing"

--- a/collectors/node/load.go
+++ b/collectors/node/load.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/collectors/node/load.go
+++ b/collectors/node/load.go
@@ -1,0 +1,56 @@
+package node
+
+import (
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/shirou/gopsutil/load"
+)
+
+type loadMetric struct {
+	load1Min  float64
+	load5Min  float64
+	load15Min float64
+	timestamp string
+}
+
+func (m *loadMetric) poll() error {
+	ts := thisTime()
+	l, err := load.Avg()
+	if err != nil {
+		return err
+	}
+
+	m.load1Min = l.Load1
+	m.load5Min = l.Load5
+	m.load15Min = l.Load15
+	m.timestamp = ts
+
+	return nil
+}
+
+func (m *loadMetric) addDatapoints(nc *nodeCollector) error {
+	loadDps := []producers.Datapoint{
+		producers.Datapoint{
+			Name:      LOAD_1MIN,
+			Unit:      COUNT,
+			Value:     m.load1Min,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      LOAD_5MIN,
+			Unit:      COUNT,
+			Value:     m.load5Min,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      LOAD_15MIN,
+			Unit:      COUNT,
+			Value:     m.load15Min,
+			Timestamp: m.timestamp,
+		},
+	}
+	for _, dp := range loadDps {
+		nc.datapoints = append(nc.datapoints, dp)
+	}
+
+	return nil
+}

--- a/collectors/node/load.go
+++ b/collectors/node/load.go
@@ -41,8 +41,8 @@ func (m *loadMetric) poll() error {
 	return nil
 }
 
-func (m *loadMetric) addDatapoints(nc *nodeCollector) error {
-	loadDps := []producers.Datapoint{
+func (m *loadMetric) getDatapoints() ([]producers.Datapoint, error) {
+	return []producers.Datapoint{
 		producers.Datapoint{
 			Name:      LOAD_1MIN,
 			Unit:      COUNT,
@@ -61,10 +61,5 @@ func (m *loadMetric) addDatapoints(nc *nodeCollector) error {
 			Value:     m.load15Min,
 			Timestamp: m.timestamp,
 		},
-	}
-	for _, dp := range loadDps {
-		nc.datapoints = append(nc.datapoints, dp)
-	}
-
-	return nil
+	}, nil
 }

--- a/collectors/node/load_test.go
+++ b/collectors/node/load_test.go
@@ -1,0 +1,26 @@
+package node
+
+import "testing"
+
+var mockLoad = loadMetric{
+	load1Min:  float64(0.42),
+	load5Min:  float64(0.58),
+	load15Min: float64(0.57),
+	timestamp: "2009-11-10T23:00:00Z",
+}
+
+func TestLoadAddDatapoints(t *testing.T) {
+
+	mockNc := nodeCollector{}
+
+	err := mockLoad.addDatapoints(&mockNc)
+
+	if err != nil {
+		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
+	}
+
+	if len(mockNc.datapoints) != 3 {
+		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+	}
+
+}

--- a/collectors/node/load_test.go
+++ b/collectors/node/load_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import "testing"

--- a/collectors/node/load_test.go
+++ b/collectors/node/load_test.go
@@ -27,13 +27,13 @@ func TestLoadAddDatapoints(t *testing.T) {
 
 	mockNc := nodeCollector{}
 
-	err := mockLoad.addDatapoints(&mockNc)
+	dps, err := mockLoad.getDatapoints()
 
 	if err != nil {
 		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
 	}
 
-	if len(mockNc.datapoints) != 3 {
+	if len(dps) != 3 {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 

--- a/collectors/node/memory.go
+++ b/collectors/node/memory.go
@@ -34,17 +34,17 @@ func (m *memoryMetric) poll() error {
 	ts := thisTime()
 	m.timestamp = ts
 
-	mem, err := getMemory()
+	virt, err := mem.VirtualMemory()
 	if err != nil {
 		return err
 	}
 
-	m.memTotal = mem.Total
-	m.memFree = mem.Free
-	m.memBuffers = mem.Buffers
-	m.memCached = mem.Cached
+	m.memTotal = virt.Total
+	m.memFree = virt.Free
+	m.memBuffers = virt.Buffers
+	m.memCached = virt.Cached
 
-	swap, err := getSwap()
+	swap, err := mem.SwapMemory()
 	if err != nil {
 		return err
 	}
@@ -101,16 +101,4 @@ func (m *memoryMetric) getDatapoints() ([]producers.Datapoint, error) {
 			Timestamp: m.timestamp,
 		},
 	}, nil
-}
-
-/* Helpers */
-
-func getMemory() (*mem.VirtualMemoryStat, error) {
-	m, err := mem.VirtualMemory()
-	return m, err
-}
-
-func getSwap() (*mem.SwapMemoryStat, error) {
-	s, err := mem.SwapMemory()
-	return s, err
 }

--- a/collectors/node/memory.go
+++ b/collectors/node/memory.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/collectors/node/memory.go
+++ b/collectors/node/memory.go
@@ -1,0 +1,108 @@
+package node
+
+import (
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/shirou/gopsutil/mem"
+)
+
+type memoryMetric struct {
+	memTotal   uint64
+	memFree    uint64
+	memBuffers uint64
+	memCached  uint64
+	swapTotal  uint64
+	swapFree   uint64
+	swapUsed   uint64
+	timestamp  string
+}
+
+func (m *memoryMetric) poll() error {
+	ts := thisTime()
+	m.timestamp = ts
+
+	mem, err := getMemory()
+	if err != nil {
+		return err
+	}
+
+	m.memTotal = mem.Total
+	m.memFree = mem.Free
+	m.memBuffers = mem.Buffers
+	m.memCached = mem.Cached
+
+	swap, err := getSwap()
+	if err != nil {
+		return err
+	}
+
+	m.swapTotal = swap.Total
+	m.swapFree = swap.Free
+	m.swapUsed = swap.Used
+
+	return nil
+}
+
+func (m *memoryMetric) addDatapoints(nc *nodeCollector) error {
+	memDps := []producers.Datapoint{
+		producers.Datapoint{
+			Name:      MEM_TOTAL,
+			Unit:      BYTES,
+			Value:     m.memTotal,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      MEM_FREE,
+			Unit:      BYTES,
+			Value:     m.memFree,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      MEM_BUFFERS,
+			Unit:      BYTES,
+			Value:     m.memBuffers,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      MEM_CACHED,
+			Unit:      BYTES,
+			Value:     m.memCached,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      SWAP_TOTAL,
+			Unit:      BYTES,
+			Value:     m.swapTotal,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      SWAP_FREE,
+			Unit:      BYTES,
+			Value:     m.swapFree,
+			Timestamp: m.timestamp,
+		},
+		producers.Datapoint{
+			Name:      SWAP_USED,
+			Unit:      BYTES,
+			Value:     m.swapUsed,
+			Timestamp: m.timestamp,
+		},
+	}
+
+	for _, dp := range memDps {
+		nc.datapoints = append(nc.datapoints, dp)
+	}
+
+	return nil
+}
+
+/* Helpers */
+
+func getMemory() (*mem.VirtualMemoryStat, error) {
+	m, err := mem.VirtualMemory()
+	return m, err
+}
+
+func getSwap() (*mem.SwapMemoryStat, error) {
+	s, err := mem.SwapMemory()
+	return s, err
+}

--- a/collectors/node/memory.go
+++ b/collectors/node/memory.go
@@ -56,8 +56,8 @@ func (m *memoryMetric) poll() error {
 	return nil
 }
 
-func (m *memoryMetric) addDatapoints(nc *nodeCollector) error {
-	memDps := []producers.Datapoint{
+func (m *memoryMetric) getDatapoints() ([]producers.Datapoint, error) {
+	return []producers.Datapoint{
 		producers.Datapoint{
 			Name:      MEM_TOTAL,
 			Unit:      BYTES,
@@ -100,13 +100,7 @@ func (m *memoryMetric) addDatapoints(nc *nodeCollector) error {
 			Value:     m.swapUsed,
 			Timestamp: m.timestamp,
 		},
-	}
-
-	for _, dp := range memDps {
-		nc.datapoints = append(nc.datapoints, dp)
-	}
-
-	return nil
+	}, nil
 }
 
 /* Helpers */

--- a/collectors/node/memory_test.go
+++ b/collectors/node/memory_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import "testing"

--- a/collectors/node/memory_test.go
+++ b/collectors/node/memory_test.go
@@ -1,0 +1,29 @@
+package node
+
+import "testing"
+
+var mockMemory = memoryMetric{
+	memTotal:   uint64(16310888 * 1024),
+	memFree:    uint64(9121592 * 1024),
+	memBuffers: uint64(101784 * 1024),
+	memCached:  uint64(2909412 * 1024),
+	swapTotal:  uint64(16658428 * 1024),
+	swapFree:   uint64(16658421 * 1024),
+	swapUsed:   uint64(1 * 1024),
+	timestamp:  "2009-11-10T23:00:00Z",
+}
+
+func TestMemoryAddDatapoints(t *testing.T) {
+	mockNc := nodeCollector{}
+
+	err := mockMemory.addDatapoints(&mockNc)
+
+	if err != nil {
+		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
+	}
+
+	if len(mockNc.datapoints) != 7 {
+		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+	}
+
+}

--- a/collectors/node/memory_test.go
+++ b/collectors/node/memory_test.go
@@ -30,13 +30,13 @@ var mockMemory = memoryMetric{
 func TestMemoryAddDatapoints(t *testing.T) {
 	mockNc := nodeCollector{}
 
-	err := mockMemory.addDatapoints(&mockNc)
+	dps, err := mockMemory.getDatapoints()
 
 	if err != nil {
 		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
 	}
 
-	if len(mockNc.datapoints) != 7 {
+	if len(dps) != 7 {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 

--- a/collectors/node/metrics.go
+++ b/collectors/node/metrics.go
@@ -80,7 +80,7 @@ type nodeCollector struct {
 
 type nodeMetricPoller interface {
 	poll() error
-	addDatapoints(*nodeCollector) error
+	getDatapoints() ([]producers.Datapoint, error)
 }
 
 func getNodeMetrics() ([]producers.Datapoint, error) {
@@ -104,8 +104,10 @@ func getNodeMetrics() ([]producers.Datapoint, error) {
 			return nc.datapoints, err
 		}
 
-		if err := mp.addDatapoints(&nc); err != nil {
+		if dps, err := mp.getDatapoints(); err != nil {
 			return nc.datapoints, err
+		} else {
+			nc.datapoints = append(nc.datapoints, dps...)
 		}
 	}
 

--- a/collectors/node/metrics.go
+++ b/collectors/node/metrics.go
@@ -15,225 +15,105 @@
 package node
 
 import (
-	"math"
-	"sync"
+	"time"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/disk"
-	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/load"
-	"github.com/shirou/gopsutil/mem"
-	"github.com/shirou/gopsutil/net"
+	"github.com/dcos/dcos-metrics/producers"
 )
 
-type nodeMetrics struct {
-	Uptime       uint64 `json:"uptime"`
-	ProcessCount uint64 `json:"processes"`
+const (
+	// Unit constants
+	COUNT = "count"
+	BYTES = "bytes"
 
-	NumCores  int32   `json:"cpu.cores"`
-	Load1Min  float64 `json:"load.1min"`
-	Load5Min  float64 `json:"load.5min"`
-	Load15Min float64 `json:"load.15min"`
+	/* Metric name constants */
+	UPTIME = "uptime"
 
-	CPUTotalPct  float64 `json:"cpu.total"`
-	CPUUserPct   float64 `json:"cpu.user"`
-	CPUSystemPct float64 `json:"cpu.system"`
-	CPUIdlePct   float64 `json:"cpu.idle"`
-	CPUWaitPct   float64 `json:"cpu.wait"`
+	/* process.<namespace> */
+	PROCESS_COUNT = "process.count"
 
-	MemTotalBytes   uint64 `json:"memory.total"`
-	MemFreeBytes    uint64 `json:"memory.free"`
-	MemBuffersBytes uint64 `json:"memory.buffers"`
-	MemCachedBytes  uint64 `json:"memory.cached"`
+	/* load.<namespace> */
+	LOAD_1MIN  = "load.1min"
+	LOAD_5MIN  = "load.5min"
+	LOAD_15MIN = "load.15min"
 
-	SwapTotalBytes uint64 `json:"swap.total"`
-	SwapFreeBytes  uint64 `json:"swap.free"`
-	SwapUsedBytes  uint64 `json:"swap.used"`
+	/* load.<namespace> */
+	CPU_CORES  = "cpu.cores"
+	CPU_TOTAL  = "cpu.total"
+	CPU_USER   = "cpu.user"
+	CPU_SYSTEM = "cpu.system"
+	CPU_IDLE   = "cpu.idle"
+	CPU_WAIT   = "cpu.wait"
 
-	Filesystems       []nodeFilesystem       `json:"filesystems"`
-	NetworkInterfaces []nodeNetworkInterface `json:"network_interfaces"`
+	/* filesystem.<namespace> */
+	FS_CAP_TOTAL   = "filesystem.capacity.total"
+	FS_CAP_USED    = "filesystem.capacity.used"
+	FS_CAP_FREE    = "filesystem.capacity.free"
+	FS_INODE_TOTAL = "filesystem.inode.total"
+	FS_INODE_USED  = "filesystem.inode.used"
+	FS_INODE_FREE  = "filesystem.inode.free"
+
+	/* network.<namespace> */
+	NET_IN          = "network.in"
+	NET_OUT         = "network.out"
+	NET_IN_PACKETS  = "network.in.packets"
+	NET_OUT_PACKETS = "network.out.packets"
+	NET_IN_DROPPED  = "network_in_dropped"
+	NET_OUT_DROPPED = "network_out_dropped"
+	NET_IN_ERRORS   = "network_in_errors"
+	NET_OUT_ERRORS  = "network_out_errors"
+
+	/* memory.<namespace> */
+	MEM_TOTAL   = "memory.total"
+	MEM_FREE    = "memory.free"
+	MEM_BUFFERS = "memory.buffers"
+	MEM_CACHED  = "memory.cached"
+
+	/* swap.<namespace> */
+	SWAP_TOTAL = "swap.total"
+	SWAP_FREE  = "swap.free"
+	SWAP_USED  = "swap.used"
+)
+
+type nodeCollector struct {
+	datapoints []producers.Datapoint
 }
 
-type nodeFilesystem struct {
-	Name               string `json:"name"`
-	CapacityTotalBytes uint64 `json:"filesystem.{{.Name}}.capacity.total"`
-	CapacityUsedBytes  uint64 `json:"filesystem.{{.Name}}.capacity.used"`
-	CapacityFreeBytes  uint64 `json:"filesystem.{{.Name}}.capacity.free"`
-	InodesTotal        uint64 `json:"filesystem.{{.Name}}.inodes.total"`
-	InodesUsed         uint64 `json:"filesystem.{{.Name}}.inodes.used"`
-	InodesFree         uint64 `json:"filesystem.{{.Name}}.inodes.free"`
+type nodeMetricPoller interface {
+	poll() error
+	addDatapoints(*nodeCollector) error
 }
 
-type nodeNetworkInterface struct {
-	Name      string `json:"name"`
-	RxBytes   uint64 `json:"network.{{.Name}}.in.bytes"`
-	TxBytes   uint64 `json:"network.{{.Name}}.out.bytes"`
-	RxPackets uint64 `json:"network.{{.Name}}.in.packets"`
-	TxPackets uint64 `json:"network.{{.Name}}.out.packets"`
-	RxDropped uint64 `json:"network.{{.Name}}.in.dropped"`
-	TxDropped uint64 `json:"network.{{.Name}}.out.dropped"`
-	RxErrors  uint64 `json:"network.{{.Name}}.in.errors"`
-	TxErrors  uint64 `json:"network.{{.Name}}.out.errors"`
-}
+func getNodeMetrics() ([]producers.Datapoint, error) {
+	nc := nodeCollector{}
 
-func getNodeMetrics() (nodeMetrics, error) {
-	l := getLoadAvg()
-	cpuStatePcts := calculatePcts(getCPUTimes())
-	m := getMemory()
-	s := getSwap()
+	nodeMetricPollers := []nodeMetricPoller{
+		&uptimeMetric{},
+		&cpuCoresMetric{},
+		&loadMetric{},
+		&filesystemMetrics{},
+		&memoryMetric{},
+		&networkMetrics{},
+		&processMetrics{},
+	}
 
-	return nodeMetrics{
-		Uptime:       getUptime(),
-		ProcessCount: getProcessCount(),
+	// For each metric poller defined, execute .poll() to get the latest
+	// metric, check for errors, and iterate over the slice of producers.Datapoint
+	// returned by .poll(), adding them to our top scope nodeMetrics slice.
+	for _, mp := range nodeMetricPollers {
+		if err := mp.poll(); err != nil {
+			return nc.datapoints, err
+		}
 
-		NumCores:  getNumCores(),
-		Load1Min:  l.Load1,
-		Load5Min:  l.Load5,
-		Load15Min: l.Load15,
+		if err := mp.addDatapoints(&nc); err != nil {
+			return nc.datapoints, err
+		}
+	}
 
-		// Percentages are calculated between the last poll of the CPU times
-		// and the current times, as stored in lastCPU. 100.00 => 100.00%
-		CPUTotalPct:  cpuStatePcts.User + cpuStatePcts.System,
-		CPUUserPct:   cpuStatePcts.User,
-		CPUSystemPct: cpuStatePcts.System,
-		CPUIdlePct:   cpuStatePcts.Idle,
-		CPUWaitPct:   cpuStatePcts.Iowait,
-
-		MemTotalBytes:   m.Total,
-		MemFreeBytes:    m.Free,
-		MemBuffersBytes: m.Buffers,
-		MemCachedBytes:  m.Cached,
-
-		SwapTotalBytes: s.Total,
-		SwapFreeBytes:  s.Free,
-		SwapUsedBytes:  s.Used,
-
-		Filesystems:       getFilesystems(),
-		NetworkInterfaces: getNetworkInterfaces(),
-	}, nil
+	return nc.datapoints, nil
 }
 
 // -- helpers
 
-type lastCPUTimes struct {
-	sync.Mutex
-	times cpu.TimesStat
-}
-
-var lastCPU lastCPUTimes
-
-func init() {
-	t, _ := cpu.Times(false) // get totals, not per-cpu stats
-	lastCPU.Lock()
-	lastCPU.times = t[0]
-	lastCPU.Unlock()
-}
-
-func getUptime() uint64 {
-	uptime, _ := host.Uptime()
-	return uptime
-}
-
-func getProcessCount() uint64 {
-	i, _ := host.Info()
-	return i.Procs
-}
-
-func getNumCores() int32 {
-	cores := int32(0)
-	cpus, _ := cpu.Info()
-	for _, c := range cpus {
-		cores += c.Cores
-	}
-	return cores
-}
-
-func getLoadAvg() *load.AvgStat {
-	l, _ := load.Avg()
-	return l
-}
-
-func getCPUTimes() (cpu.TimesStat, cpu.TimesStat) {
-	currentTimes, _ := cpu.Times(false) // get totals, not per-cpu stats
-	lastTimes := lastCPU.times
-
-	lastCPU.Lock()
-	lastCPU.times = currentTimes[0] // update lastTimes to the currentTimes
-	lastCPU.Unlock()
-
-	return currentTimes[0], lastTimes
-}
-
-func getMemory() *mem.VirtualMemoryStat {
-	m, _ := mem.VirtualMemory()
-	return m
-}
-
-func getSwap() *mem.SwapMemoryStat {
-	s, _ := mem.SwapMemory()
-	return s
-}
-
-func getFilesystems() []nodeFilesystem {
-	f := []nodeFilesystem{}
-	parts, _ := disk.Partitions(false) // only physical partitions
-	for _, part := range parts {
-		usage, _ := disk.Usage(part.Mountpoint)
-		f = append(f, nodeFilesystem{
-			Name:               usage.Path,
-			CapacityTotalBytes: usage.Total,
-			CapacityUsedBytes:  usage.Used,
-			CapacityFreeBytes:  usage.Free,
-			InodesTotal:        usage.InodesTotal,
-			InodesUsed:         usage.InodesUsed,
-			InodesFree:         usage.InodesFree,
-		})
-	}
-	return f
-}
-
-func getNetworkInterfaces() []nodeNetworkInterface {
-	n := []nodeNetworkInterface{}
-	ioc, _ := net.IOCounters(true) // per nic
-	for _, nic := range ioc {
-		n = append(n, nodeNetworkInterface{
-			Name:      nic.Name,
-			RxBytes:   nic.BytesRecv,
-			TxBytes:   nic.BytesSent,
-			RxPackets: nic.PacketsRecv,
-			TxPackets: nic.PacketsSent,
-			RxDropped: nic.Dropin,
-			TxDropped: nic.Dropout,
-			RxErrors:  nic.Errin,
-			TxErrors:  nic.Errout,
-		})
-	}
-	return n
-}
-
-// calculatePct returns the percent utilization for CPU states. 100.00 => 100.00%
-func calculatePcts(lastTimes cpu.TimesStat, curTimes cpu.TimesStat) cpu.TimesStat {
-	totalDelta := curTimes.Total() - lastTimes.Total()
-	if totalDelta == 0 {
-		totalDelta = 1 // can't divide by zero
-	}
-	return cpu.TimesStat{
-		User:      round(math.Dim(curTimes.User, lastTimes.User) / totalDelta * 100),
-		System:    round(math.Dim(curTimes.System, lastTimes.System) / totalDelta * 100),
-		Idle:      round(math.Dim(curTimes.Idle, lastTimes.Idle) / totalDelta * 100),
-		Nice:      round(math.Dim(curTimes.Nice, lastTimes.Nice) / totalDelta * 100),
-		Iowait:    round(math.Dim(curTimes.Iowait, lastTimes.Iowait) / totalDelta * 100),
-		Irq:       round(math.Dim(curTimes.Irq, lastTimes.Irq) / totalDelta * 100),
-		Softirq:   round(math.Dim(curTimes.Softirq, lastTimes.Softirq) / totalDelta * 100),
-		Steal:     round(math.Dim(curTimes.Steal, lastTimes.Steal) / totalDelta * 100),
-		Guest:     round(math.Dim(curTimes.Guest, lastTimes.Guest) / totalDelta * 100),
-		GuestNice: round(math.Dim(curTimes.GuestNice, lastTimes.GuestNice) / totalDelta * 100),
-		Stolen:    round(math.Dim(curTimes.Stolen, lastTimes.Stolen) / totalDelta * 100),
-	}
-}
-
-// Helper function for rounding to two decimal places
-func round(f float64) float64 {
-	shift := math.Pow(10, float64(2))
-	return math.Floor(f*shift+.5) / shift
+func thisTime() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
 }

--- a/collectors/node/metrics_test.go
+++ b/collectors/node/metrics_test.go
@@ -17,12 +17,9 @@
 package node
 
 import (
-	"reflect"
 	"testing"
-	"time"
 
 	"github.com/dcos/dcos-metrics/producers"
-	"github.com/shirou/gopsutil/cpu"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -38,114 +35,3 @@ func TestGetNodeMetrics(t *testing.T) {
 		}
 	})
 }
-
-func TestCalculatePcts(t *testing.T) {
-	lastTimes := cpu.TimesStat{
-		CPU:       "cpu-total",
-		User:      20564.8,
-		System:    5355.2,
-		Idle:      3866.2,
-		Nice:      1141.0,
-		Iowait:    161.4,
-		Irq:       0.0,
-		Softirq:   138.8,
-		Steal:     0.0,
-		Guest:     0.0,
-		GuestNice: 0.0,
-		Stolen:    0.0,
-	}
-	currentTimes := cpu.TimesStat{
-		CPU:       "cpu-total",
-		User:      20675.6,
-		System:    5388.1,
-		Idle:      39568.8,
-		Nice:      1141.0,
-		Iowait:    164.5,
-		Irq:       0.0,
-		Softirq:   139.2,
-		Steal:     0.0,
-		Guest:     0.0,
-		GuestNice: 0.0,
-		Stolen:    0.0,
-	}
-
-	Convey("When calculating CPU state percentages", t, func() {
-		pcts := calculatePcts(lastTimes, currentTimes)
-		Convey("Percentages should be calculated to two decimal places", func() {
-			So(pcts.User, ShouldEqual, 0.31)
-			So(pcts.System, ShouldEqual, 0.09)
-			So(pcts.Idle, ShouldEqual, 99.59)
-			So(pcts.Iowait, ShouldEqual, 0.01)
-		})
-		Convey("No percentages should be negative", func() {
-			v := reflect.ValueOf(pcts)
-			for i := 0; i < v.NumField(); i++ {
-				if v.Field(i).Kind() == reflect.String {
-					continue
-				}
-				So(v.Field(i).Interface(), ShouldBeGreaterThanOrEqualTo, 0)
-			}
-		})
-	})
-}
-
-func TestRound(t *testing.T) {
-	Convey("When rounding float64 values to two decimal places", t, func() {
-		Convey("Should work on all numbers", func() {
-			testCases := []struct {
-				input    float64
-				expected float64
-			}{
-				{-123.456, -123.46},
-				{123.456, 123.46},
-				{0, 0.00},
-				{-1, -1.00},
-				{100.00000, 100.00},
-				{100, 100.00},
-			}
-
-			for _, tc := range testCases {
-				So(round(tc.input), ShouldEqual, tc.expected)
-			}
-		})
-	})
-}
-
-func TestInit(t *testing.T) {
-	Convey("When initializing the node metrics collector", t, func() {
-		Convey("Should automatically set lastCPU times", func() {
-			So(lastCPU.times.CPU, ShouldNotEqual, "")
-		})
-	})
-}
-
-func TestGetCPUTimes(t *testing.T) {
-	Convey("When getting CPU times", t, func() {
-		Convey("Should return both the current times and last times (so that percentages can be calculated)", func() {
-			time.Sleep(1 * time.Second)
-			cur, last := getCPUTimes()
-			So(cur.User, ShouldBeGreaterThan, last.User)
-			So(cur.Idle, ShouldBeGreaterThan, last.Idle)
-		})
-	})
-}
-
-//func TestGetFilesystems(t *testing.T) {
-//	Convey("When getting filesystems", t, func() {
-//		Convey("Should return a list containing nodeFilesystem{} structs", func() {
-//			fs := getFilesystems()
-//			So(len(fs), ShouldBeGreaterThan, 0)
-//			So(fs, ShouldHaveSameTypeAs, []nodeFilesystem{})
-//		})
-//	})
-//}
-//
-//func TestGetNetworkInterfaces(t *testing.T) {
-//	Convey("When getting network interfaces", t, func() {
-//		Convey("Should return a list containing nodeNetworkInterface{} structs", func() {
-//			ifs := getNetworkInterfaces()
-//			So(len(ifs), ShouldBeGreaterThan, 0)
-//			So(ifs, ShouldHaveSameTypeAs, []nodeNetworkInterface{})
-//		})
-//	})
-//}

--- a/collectors/node/metrics_test.go
+++ b/collectors/node/metrics_test.go
@@ -21,84 +21,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dcos/dcos-metrics/producers"
 	"github.com/shirou/gopsutil/cpu"
 	. "github.com/smartystreets/goconvey/convey"
-)
-
-var (
-	mockNodeMetrics = nodeMetrics{
-		Uptime:          uint64(7865),
-		ProcessCount:    3,
-		NumCores:        4,
-		Load1Min:        float64(0.42),
-		Load5Min:        float64(0.58),
-		Load15Min:       float64(0.57),
-		CPUTotalPct:     float64(12.50),
-		CPUUserPct:      float64(9.60),
-		CPUSystemPct:    float64(2.90),
-		CPUIdlePct:      float64(87.40),
-		CPUWaitPct:      float64(0.10),
-		MemTotalBytes:   uint64(16310888 * 1024),
-		MemFreeBytes:    uint64(9121592 * 1024),
-		MemBuffersBytes: uint64(101784 * 1024),
-		MemCachedBytes:  uint64(2909412 * 1024),
-		SwapTotalBytes:  uint64(16658428 * 1024),
-		SwapFreeBytes:   uint64(16658421 * 1024),
-		SwapUsedBytes:   uint64(1 * 1024),
-		Filesystems: []nodeFilesystem{
-			nodeFilesystem{
-				Name:               "/",
-				CapacityTotalBytes: uint64(449660412 * 1024),
-				CapacityUsedBytes:  uint64(25819220 * 1024),
-				CapacityFreeBytes:  uint64(423841192 * 1024),
-			},
-			nodeFilesystem{
-				Name:               "/boot",
-				CapacityTotalBytes: uint64(458961 * 1024),
-				CapacityUsedBytes:  uint64(191925 * 1024),
-				CapacityFreeBytes:  uint64(267036 * 1024),
-			},
-		},
-		NetworkInterfaces: []nodeNetworkInterface{
-			nodeNetworkInterface{
-				Name:      "eth0",
-				RxBytes:   uint64(260522667),
-				TxBytes:   uint64(10451619),
-				RxPackets: uint64(1058595),
-				TxPackets: uint64(62547),
-				RxDropped: uint64(99),
-				TxDropped: uint64(99),
-				RxErrors:  uint64(99),
-				TxErrors:  uint64(99),
-			},
-			nodeNetworkInterface{
-				Name:      "lo",
-				RxBytes:   uint64(7939933),
-				TxBytes:   uint64(8139647),
-				RxPackets: uint64(133276),
-				TxPackets: uint64(133002),
-				RxDropped: uint64(88),
-				TxDropped: uint64(88),
-				RxErrors:  uint64(88),
-				TxErrors:  uint64(88),
-			},
-		},
-	}
 )
 
 func TestGetNodeMetrics(t *testing.T) {
 	Convey("When getting node metrics, should return nodeMetrics type", t, func() {
 		m, err := getNodeMetrics()
 		So(err, ShouldBeNil)
-		So(m, ShouldHaveSameTypeAs, nodeMetrics{})
 
-		// smoke test certain values that should always be > 0
-		So(m.Uptime, ShouldBeGreaterThan, 0)
-		So(m.ProcessCount, ShouldBeGreaterThan, 0)
-		So(m.NumCores, ShouldBeGreaterThan, 0)
-		So(m.MemTotalBytes, ShouldBeGreaterThan, 0)
-		So(len(m.Filesystems), ShouldBeGreaterThan, 0)
-		So(len(m.NetworkInterfaces), ShouldBeGreaterThan, 0)
+		So(len(m), ShouldBeGreaterThan, 0)
+
+		for _, dp := range m {
+			So(dp, ShouldHaveSameTypeAs, producers.Datapoint{})
+		}
 	})
 }
 
@@ -193,22 +130,22 @@ func TestGetCPUTimes(t *testing.T) {
 	})
 }
 
-func TestGetFilesystems(t *testing.T) {
-	Convey("When getting filesystems", t, func() {
-		Convey("Should return a list containing nodeFilesystem{} structs", func() {
-			fs := getFilesystems()
-			So(len(fs), ShouldBeGreaterThan, 0)
-			So(fs, ShouldHaveSameTypeAs, []nodeFilesystem{})
-		})
-	})
-}
-
-func TestGetNetworkInterfaces(t *testing.T) {
-	Convey("When getting network interfaces", t, func() {
-		Convey("Should return a list containing nodeNetworkInterface{} structs", func() {
-			ifs := getNetworkInterfaces()
-			So(len(ifs), ShouldBeGreaterThan, 0)
-			So(ifs, ShouldHaveSameTypeAs, []nodeNetworkInterface{})
-		})
-	})
-}
+//func TestGetFilesystems(t *testing.T) {
+//	Convey("When getting filesystems", t, func() {
+//		Convey("Should return a list containing nodeFilesystem{} structs", func() {
+//			fs := getFilesystems()
+//			So(len(fs), ShouldBeGreaterThan, 0)
+//			So(fs, ShouldHaveSameTypeAs, []nodeFilesystem{})
+//		})
+//	})
+//}
+//
+//func TestGetNetworkInterfaces(t *testing.T) {
+//	Convey("When getting network interfaces", t, func() {
+//		Convey("Should return a list containing nodeNetworkInterface{} structs", func() {
+//			ifs := getNetworkInterfaces()
+//			So(len(ifs), ShouldBeGreaterThan, 0)
+//			So(ifs, ShouldHaveSameTypeAs, []nodeNetworkInterface{})
+//		})
+//	})
+//}

--- a/collectors/node/network.go
+++ b/collectors/node/network.go
@@ -65,10 +65,10 @@ func (m *networkMetrics) poll() error {
 	return nil
 }
 
-func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
-
+func (m *networkMetrics) getDatapoints() ([]producers.Datapoint, error) {
+	var ncDps []producers.Datapoint
 	for _, nic := range m.interfaces {
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_IN,
 			Unit:      BYTES,
 			Value:     nic.netIn,
@@ -78,7 +78,7 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_OUT,
 			Unit:      BYTES,
 			Value:     nic.netOut,
@@ -88,7 +88,7 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_IN_PACKETS,
 			Unit:      COUNT,
 			Value:     nic.netInPackets,
@@ -98,7 +98,7 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_OUT_PACKETS,
 			Unit:      COUNT,
 			Value:     nic.netOutPackets,
@@ -108,7 +108,7 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_IN_DROPPED,
 			Unit:      COUNT,
 			Value:     nic.netInDropped,
@@ -118,7 +118,7 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_OUT_DROPPED,
 			Unit:      COUNT,
 			Value:     nic.netOutDropped,
@@ -128,7 +128,7 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_IN_ERRORS,
 			Unit:      COUNT,
 			Value:     nic.netInErrors,
@@ -138,7 +138,7 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 			},
 		})
 
-		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		ncDps = append(ncDps, producers.Datapoint{
 			Name:      NET_OUT_ERRORS,
 			Unit:      COUNT,
 			Value:     nic.netOutErrors,
@@ -149,5 +149,5 @@ func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
 		})
 	}
 
-	return nil
+	return ncDps, nil
 }

--- a/collectors/node/network.go
+++ b/collectors/node/network.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/collectors/node/network.go
+++ b/collectors/node/network.go
@@ -1,0 +1,139 @@
+package node
+
+import (
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/shirou/gopsutil/net"
+)
+
+type networkMetrics struct {
+	interfaces []networkMetric
+}
+
+type networkMetric struct {
+	interfaceName string
+	netIn         uint64
+	netOut        uint64
+	netInPackets  uint64
+	netOutPackets uint64
+	netInDropped  uint64
+	netOutDropped uint64
+	netInErrors   uint64
+	netOutErrors  uint64
+	timestamp     string
+}
+
+func (m *networkMetrics) poll() error {
+	netMetrics := []networkMetric{}
+
+	ts := thisTime()
+	netInterface, err := net.IOCounters(true) // per network interface
+	if err != nil {
+		return err
+	}
+
+	for _, nic := range netInterface {
+		netMetrics = append(netMetrics, networkMetric{
+			interfaceName: nic.Name,
+			netIn:         nic.BytesRecv,
+			netOut:        nic.BytesSent,
+			netInPackets:  nic.PacketsRecv,
+			netOutPackets: nic.PacketsSent,
+			netInDropped:  nic.Dropin,
+			netOutDropped: nic.Dropout,
+			netInErrors:   nic.Errin,
+			netOutErrors:  nic.Errout,
+			timestamp:     ts,
+		})
+	}
+
+	m.interfaces = netMetrics
+
+	return nil
+}
+
+func (m *networkMetrics) addDatapoints(nc *nodeCollector) error {
+
+	for _, nic := range m.interfaces {
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_IN,
+			Unit:      BYTES,
+			Value:     nic.netIn,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_OUT,
+			Unit:      BYTES,
+			Value:     nic.netOut,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_IN_PACKETS,
+			Unit:      COUNT,
+			Value:     nic.netInPackets,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_OUT_PACKETS,
+			Unit:      COUNT,
+			Value:     nic.netOutPackets,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_IN_DROPPED,
+			Unit:      COUNT,
+			Value:     nic.netInDropped,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_OUT_DROPPED,
+			Unit:      COUNT,
+			Value:     nic.netOutDropped,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_IN_ERRORS,
+			Unit:      COUNT,
+			Value:     nic.netInErrors,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+
+		nc.datapoints = append(nc.datapoints, producers.Datapoint{
+			Name:      NET_OUT_ERRORS,
+			Unit:      COUNT,
+			Value:     nic.netOutErrors,
+			Timestamp: nic.timestamp,
+			Tags: map[string]string{
+				"interface": nic.interfaceName,
+			},
+		})
+	}
+
+	return nil
+}

--- a/collectors/node/network_test.go
+++ b/collectors/node/network_test.go
@@ -1,0 +1,49 @@
+package node
+
+import "testing"
+
+var (
+	mockNet = networkMetrics{
+		interfaces: []networkMetric{
+			networkMetric{
+				interfaceName: "eth0",
+				netIn:         uint64(260522667),
+				netOut:        uint64(10451619),
+				netInPackets:  uint64(1058595),
+				netOutPackets: uint64(62547),
+				netInDropped:  uint64(99),
+				netOutDropped: uint64(99),
+				netInErrors:   uint64(99),
+				netOutErrors:  uint64(99),
+				timestamp:     "2009-11-10T23:00:00Z",
+			},
+			networkMetric{
+				interfaceName: "slv1",
+				netIn:         uint64(260522667),
+				netOut:        uint64(10451619),
+				netInPackets:  uint64(1058595),
+				netOutPackets: uint64(62547),
+				netInDropped:  uint64(99),
+				netOutDropped: uint64(99),
+				netInErrors:   uint64(99),
+				netOutErrors:  uint64(99),
+				timestamp:     "2009-11-10T23:00:00Z",
+			},
+		},
+	}
+)
+
+func TestNetworkAddDatapoints(t *testing.T) {
+	mockNc := nodeCollector{}
+
+	err := mockNet.addDatapoints(&mockNc)
+
+	if err != nil {
+		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
+	}
+
+	if len(mockNc.datapoints) != 16 {
+		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+	}
+
+}

--- a/collectors/node/network_test.go
+++ b/collectors/node/network_test.go
@@ -50,13 +50,13 @@ var (
 func TestNetworkAddDatapoints(t *testing.T) {
 	mockNc := nodeCollector{}
 
-	err := mockNet.addDatapoints(&mockNc)
+	dps, err := mockNet.getDatapoints()
 
 	if err != nil {
 		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
 	}
 
-	if len(mockNc.datapoints) != 16 {
+	if len(dps) != 16 {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 

--- a/collectors/node/network_test.go
+++ b/collectors/node/network_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import "testing"

--- a/collectors/node/node.go
+++ b/collectors/node/node.go
@@ -15,10 +15,6 @@
 package node
 
 import (
-	"bytes"
-	"reflect"
-	"strings"
-	"text/template"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -39,7 +35,7 @@ type Collector struct {
 	log *log.Entry
 
 	nodeInfo    collectors.NodeInfo
-	nodeMetrics nodeMetrics
+	nodeMetrics []producers.Datapoint
 	timestamp   int64
 }
 
@@ -93,7 +89,7 @@ func (c *Collector) transform() (out []producers.MetricsMessage) {
 	// Produce node metrics
 	msg = producers.MetricsMessage{
 		Name:       producers.NodeMetricPrefix,
-		Datapoints: c.buildDatapoints(c.nodeMetrics, t),
+		Datapoints: c.nodeMetrics,
 		Dimensions: producers.Dimensions{
 			MesosID:   c.nodeInfo.MesosID,
 			ClusterID: c.nodeInfo.ClusterID,
@@ -104,130 +100,4 @@ func (c *Collector) transform() (out []producers.MetricsMessage) {
 	out = append(out, msg)
 
 	return out
-}
-
-// buildDatapoints takes an incoming structure and builds Datapoints
-// for a MetricsMessage. It uses a normalized version of the JSON tag
-// as the datapoint name.
-func (c *Collector) buildDatapoints(in interface{}, t time.Time) []producers.Datapoint {
-	pts := []producers.Datapoint{}
-	v := reflect.Indirect(reflect.ValueOf(in))
-
-	for i := 0; i < v.NumField(); i++ { // Iterate over fields in the struct
-		f := v.Field(i)
-		typ := v.Type().Field(i)
-
-		switch f.Kind() { // Handle nested data
-		case reflect.Ptr:
-			pts = append(pts, c.buildDatapoints(f.Elem().Interface(), t)...)
-			continue
-		case reflect.Map:
-			// Ignore maps when building datapoints
-			continue
-		case reflect.Slice:
-			for j := 0; j < f.Len(); j++ {
-				for _, ndp := range c.buildDatapoints(f.Index(j).Interface(), t) {
-					pts = append(pts, ndp)
-				}
-			}
-			continue
-		case reflect.Struct:
-			pts = append(pts, c.buildDatapoints(f.Interface(), t)...)
-			continue
-		}
-
-		// Get the underlying value; see https://golang.org/pkg/reflect/#Kind
-		var uv interface{}
-		switch f.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			uv = f.Int()
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			uv = f.Uint()
-		case reflect.Float32, reflect.Float64:
-			uv = f.Float()
-		case reflect.String:
-			continue // strings aren't valid values for our metrics
-		}
-
-		// Parse JSON name (with or without templating)
-		var parsed bytes.Buffer
-		jsonName := strings.Join([]string{strings.Split(typ.Tag.Get("json"), ",")[0]}, producers.MetricNamespaceSep)
-		tmpl, err := template.New("_nodeMetricName").Parse(jsonName)
-		if err != nil {
-			c.log.Warn("Unable to build datapoint for metric with name %s, skipping", jsonName)
-			continue
-		}
-		if err := tmpl.Execute(&parsed, v.Interface()); err != nil {
-			c.log.Warn("Unable to build datapoint for metric with name %s, skipping", jsonName)
-			continue
-		}
-
-		// Get the unit for the metric
-		var un string
-		uSlice := strings.Split(parsed.String(), ".")
-
-		if len(uSlice) == 0 {
-			log.Error("Empty metric passed to buildDatapoints() function")
-			return pts
-		}
-
-		uName := uSlice[0]
-		if len(uSlice) > 1 {
-			uName = uSlice[len(uSlice)-1]
-		}
-
-		mName := uSlice[0]
-
-		const (
-			BYTES = "bytes"
-			COUNT = "count"
-		)
-
-		switch mName {
-		case "memory":
-
-			switch uName {
-			case "free", "buffers", "cached":
-				un = BYTES
-			default:
-				un = COUNT
-			}
-
-		case "swap":
-			un = BYTES
-
-		case "filesystem":
-			fsType := uName
-			if len(uSlice) >= 3 {
-				fsType = uSlice[len(uSlice)-2]
-			}
-
-			switch fsType {
-			case "capacity":
-				un = BYTES
-			default:
-				un = COUNT
-			}
-
-		case "network":
-
-			switch uName {
-			case "bytes":
-				un = BYTES
-			default:
-				un = COUNT
-			}
-
-		default:
-			un = COUNT
-		}
-
-		pts = append(pts, producers.Datapoint{
-			Name:      parsed.String(),
-			Unit:      un,
-			Value:     uv,
-			Timestamp: t.UTC().Format(time.RFC3339Nano),
-		})
-	}
-	return pts
 }

--- a/collectors/node/node_test.go
+++ b/collectors/node/node_test.go
@@ -18,11 +18,8 @@ package node
 
 import (
 	"testing"
-	"time"
 
 	"github.com/dcos/dcos-metrics/collectors"
-	"github.com/dcos/dcos-metrics/producers"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNew(t *testing.T) {
@@ -38,48 +35,4 @@ func TestNew(t *testing.T) {
 	if len(chn) != 0 {
 		t.Error("expected empty channel, got", len(chn))
 	}
-}
-
-func TestTransform(t *testing.T) {
-	mockers := []nodeMetricPoller{
-		&mockProcess,
-		&mockUptime,
-		&mockCpuMetric,
-		&mockLoad,
-		&mockMemory,
-		&mockFS,
-		&mockNet,
-	}
-	mockNodeCollector := nodeCollector{}
-
-	for _, m := range mockers {
-		m.addDatapoints(&mockNodeCollector)
-	}
-
-	Convey("When transforming agent metrics to fit producers.MetricsMessage", t, func() {
-		testTime, err := time.Parse(time.RFC3339Nano, "2009-11-10T23:00:00Z")
-		if err != nil {
-			panic(err)
-		}
-
-		nc := Collector{
-			PollPeriod:  60,
-			MetricsChan: make(chan producers.MetricsMessage),
-			nodeInfo: collectors.NodeInfo{
-				MesosID:   "test-mesos-id",
-				ClusterID: "test-cluster-id",
-			},
-			nodeMetrics: mockNodeCollector.datapoints,
-			timestamp:   testTime.UTC().Unix(),
-		}
-
-		Convey("Should return a []producers.MetricsMessage without errors", func() {
-			result := nc.transform()
-			So(len(result), ShouldEqual, 1) // one node message
-
-			// From the implementation of a.transform() and the mocks in this test file,
-			// result[0] will be container metrics.
-			So(result[0].Datapoints[0].Timestamp, ShouldEqual, "2009-11-10T23:00:00Z")
-		})
-	})
 }

--- a/collectors/node/process.go
+++ b/collectors/node/process.go
@@ -35,15 +35,14 @@ func (m *processMetrics) poll() error {
 	return nil
 }
 
-func (m *processMetrics) addDatapoints(nc *nodeCollector) error {
-	nc.datapoints = append(nc.datapoints, producers.Datapoint{
-		Name:      PROCESS_COUNT,
-		Unit:      COUNT,
-		Value:     m.processCount,
-		Timestamp: m.timestamp,
-	})
-
-	return nil
+func (m *processMetrics) getDatapoints() ([]producers.Datapoint, error) {
+	return []producers.Datapoint{
+		producers.Datapoint{
+			Name:      PROCESS_COUNT,
+			Unit:      COUNT,
+			Value:     m.processCount,
+			Timestamp: m.timestamp,
+		}}, nil
 }
 
 func getProcessCount() (uint64, error) {

--- a/collectors/node/process.go
+++ b/collectors/node/process.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/collectors/node/process.go
+++ b/collectors/node/process.go
@@ -1,0 +1,42 @@
+package node
+
+import (
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/shirou/gopsutil/host"
+)
+
+type processMetrics struct {
+	processCount uint64
+	timestamp    string
+}
+
+func (m *processMetrics) poll() error {
+	procs, err := getProcessCount()
+	if err != nil {
+		return err
+	}
+
+	m.processCount = procs
+	m.timestamp = thisTime()
+	return nil
+}
+
+func (m *processMetrics) addDatapoints(nc *nodeCollector) error {
+	nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		Name:      PROCESS_COUNT,
+		Unit:      COUNT,
+		Value:     m.processCount,
+		Timestamp: m.timestamp,
+	})
+
+	return nil
+}
+
+func getProcessCount() (uint64, error) {
+	i, err := host.Info()
+	if err != nil {
+		return 0, err
+	}
+
+	return i.Procs, nil
+}

--- a/collectors/node/process_test.go
+++ b/collectors/node/process_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import "testing"

--- a/collectors/node/process_test.go
+++ b/collectors/node/process_test.go
@@ -1,0 +1,24 @@
+package node
+
+import "testing"
+
+var mockProcess = processMetrics{
+	processCount: 3,
+	timestamp:    "2009-11-10T23:00:00Z",
+}
+
+func TestProcessAddDatapoints(t *testing.T) {
+
+	mockNc := nodeCollector{}
+
+	err := mockProcess.addDatapoints(&mockNc)
+
+	if err != nil {
+		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
+	}
+
+	if len(mockNc.datapoints) != 1 {
+		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+	}
+
+}

--- a/collectors/node/process_test.go
+++ b/collectors/node/process_test.go
@@ -25,13 +25,13 @@ func TestProcessAddDatapoints(t *testing.T) {
 
 	mockNc := nodeCollector{}
 
-	err := mockProcess.addDatapoints(&mockNc)
+	dps, err := mockProcess.getDatapoints()
 
 	if err != nil {
 		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
 	}
 
-	if len(mockNc.datapoints) != 1 {
+	if len(dps) != 1 {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 

--- a/collectors/node/uptime.go
+++ b/collectors/node/uptime.go
@@ -34,12 +34,12 @@ func (m *uptimeMetric) poll() error {
 	return nil
 }
 
-func (m *uptimeMetric) addDatapoints(nc *nodeCollector) error {
-	nc.datapoints = append(nc.datapoints, producers.Datapoint{
-		Name:      UPTIME,
-		Unit:      COUNT,
-		Value:     m.uptime,
-		Timestamp: m.timestamp,
-	})
-	return nil
+func (m *uptimeMetric) getDatapoints() ([]producers.Datapoint, error) {
+	return []producers.Datapoint{
+		producers.Datapoint{
+			Name:      UPTIME,
+			Unit:      COUNT,
+			Value:     m.uptime,
+			Timestamp: m.timestamp,
+		}}, nil
 }

--- a/collectors/node/uptime.go
+++ b/collectors/node/uptime.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import (

--- a/collectors/node/uptime.go
+++ b/collectors/node/uptime.go
@@ -1,0 +1,31 @@
+package node
+
+import (
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/shirou/gopsutil/host"
+)
+
+type uptimeMetric struct {
+	uptime    uint64
+	timestamp string
+}
+
+func (m *uptimeMetric) poll() error {
+	uptime, err := host.Uptime()
+	if err != nil {
+		return err
+	}
+	m.uptime = uptime
+	m.timestamp = thisTime()
+	return nil
+}
+
+func (m *uptimeMetric) addDatapoints(nc *nodeCollector) error {
+	nc.datapoints = append(nc.datapoints, producers.Datapoint{
+		Name:      UPTIME,
+		Unit:      COUNT,
+		Value:     m.uptime,
+		Timestamp: m.timestamp,
+	})
+	return nil
+}

--- a/collectors/node/uptime_test.go
+++ b/collectors/node/uptime_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package node
 
 import "testing"

--- a/collectors/node/uptime_test.go
+++ b/collectors/node/uptime_test.go
@@ -1,0 +1,23 @@
+package node
+
+import "testing"
+
+var mockUptime = uptimeMetric{
+	timestamp: "2009-11-10T23:00:00Z", uptime: uint64(7865),
+}
+
+func TestUptimeAddDatapoints(t *testing.T) {
+
+	mockNc := nodeCollector{}
+
+	err := mockUptime.addDatapoints(&mockNc)
+
+	if err != nil {
+		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
+	}
+
+	if len(mockNc.datapoints) != 1 {
+		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+	}
+
+}

--- a/collectors/node/uptime_test.go
+++ b/collectors/node/uptime_test.go
@@ -24,13 +24,13 @@ func TestUptimeAddDatapoints(t *testing.T) {
 
 	mockNc := nodeCollector{}
 
-	err := mockUptime.addDatapoints(&mockNc)
+	dps, err := mockUptime.getDatapoints()
 
 	if err != nil {
 		t.Errorf("Expected no errors getting datapoints from mockCPU, got %s", err.Error())
 	}
 
-	if len(mockNc.datapoints) != 1 {
+	if len(dps) != 1 {
 		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
 	}
 

--- a/producers/interface.go
+++ b/producers/interface.go
@@ -54,10 +54,11 @@ type MetricsMessage struct {
 // Datapoint represents a single metric's timestamp, value, and unit in a response.
 // A single datapoint is typically contained in an array, such as []Datapoint{}.
 type Datapoint struct {
-	Name      string      `json:"name"`
-	Value     interface{} `json:"value"`
-	Unit      string      `json:"unit"`
-	Timestamp string      `json:"timestamp"` // time.RFC3339, e.g. "2016-01-01T01:01:01Z"
+	Name      string            `json:"name"`
+	Value     interface{}       `json:"value"`
+	Unit      string            `json:"unit"`
+	Timestamp string            `json:"timestamp"` // time.RFC3339, e.g. "2016-01-01T01:01:01Z"
+	Tags      map[string]string `json:"tags,omitempty"`
 }
 
 // Dimensions are metadata about the metrics contained in a given MetricsMessage.


### PR DESCRIPTION
- [x] Fix unit names
- [x] Enable tagging metrics
- [x] Update unit tests
- [x] Push logic of metric transformation down to the methods which gather the metrics rather than the generic transform method in the top level node collection

## For reviewers
This is a very large PR. I've structured the commits in a logical order to make this easier to digest: 
- Adding unit values to the metrics 
- Adding `tags` parameter to the `producers.MetricMessage{}` interface
- Enabling the usage of a generic `nodeMetricPoller` type for metric gathering
- Then, adding a file and the associated unit test for each metric type

This commit history should be clean enough to work through commit-by-commit, and I suggest it be done that way for sanity sake. TIA. 

## Integration
PR to DC/OS: https://github.com/dcos/dcos/pull/1155