### PR TITLE
Add per-process metrics

### DIFF
--- a/collectors/node/cpu.go
+++ b/collectors/node/cpu.go
@@ -22,6 +22,16 @@ import (
 	"github.com/shirou/gopsutil/cpu"
 )
 
+const (
+	/* load.<namespace> */
+	CPU_CORES  = "cpu.cores"
+	CPU_TOTAL  = "cpu.total"
+	CPU_USER   = "cpu.user"
+	CPU_SYSTEM = "cpu.system"
+	CPU_IDLE   = "cpu.idle"
+	CPU_WAIT   = "cpu.wait"
+)
+
 type cpuCoresMetric struct {
 	cpuCores  int32
 	cpuTotal  float64

--- a/collectors/node/filesystem.go
+++ b/collectors/node/filesystem.go
@@ -19,6 +19,16 @@ import (
 	"github.com/shirou/gopsutil/disk"
 )
 
+const (
+	/* filesystem.<namespace> */
+	FS_CAP_TOTAL   = "filesystem.capacity.total"
+	FS_CAP_USED    = "filesystem.capacity.used"
+	FS_CAP_FREE    = "filesystem.capacity.free"
+	FS_INODE_TOTAL = "filesystem.inode.total"
+	FS_INODE_USED  = "filesystem.inode.used"
+	FS_INODE_FREE  = "filesystem.inode.free"
+)
+
 type filesystemMetrics struct {
 	fsMetrics []filesystemMetric
 }

--- a/collectors/node/load.go
+++ b/collectors/node/load.go
@@ -19,6 +19,13 @@ import (
 	"github.com/shirou/gopsutil/load"
 )
 
+const (
+	/* load.<namespace> */
+	LOAD_1MIN  = "load.1min"
+	LOAD_5MIN  = "load.5min"
+	LOAD_15MIN = "load.15min"
+)
+
 type loadMetric struct {
 	load1Min  float64
 	load5Min  float64

--- a/collectors/node/memory.go
+++ b/collectors/node/memory.go
@@ -19,6 +19,19 @@ import (
 	"github.com/shirou/gopsutil/mem"
 )
 
+const (
+	/* memory.<namespace> */
+	MEM_TOTAL   = "memory.total"
+	MEM_FREE    = "memory.free"
+	MEM_BUFFERS = "memory.buffers"
+	MEM_CACHED  = "memory.cached"
+
+	/* swap.<namespace> */
+	SWAP_TOTAL = "swap.total"
+	SWAP_FREE  = "swap.free"
+	SWAP_USED  = "swap.used"
+)
+
 type memoryMetric struct {
 	memTotal   uint64
 	memFree    uint64

--- a/collectors/node/metrics.go
+++ b/collectors/node/metrics.go
@@ -24,55 +24,7 @@ const (
 	// Unit constants
 	COUNT = "count"
 	BYTES = "bytes"
-
-	/* Metric name constants */
-	UPTIME = "uptime"
-
-	/* process.<namespace> */
-	PROCESS_COUNT = "process.count"
-	PROCESS_PID   = "process.pid"
-
-	/* load.<namespace> */
-	LOAD_1MIN  = "load.1min"
-	LOAD_5MIN  = "load.5min"
-	LOAD_15MIN = "load.15min"
-
-	/* load.<namespace> */
-	CPU_CORES  = "cpu.cores"
-	CPU_TOTAL  = "cpu.total"
-	CPU_USER   = "cpu.user"
-	CPU_SYSTEM = "cpu.system"
-	CPU_IDLE   = "cpu.idle"
-	CPU_WAIT   = "cpu.wait"
-
-	/* filesystem.<namespace> */
-	FS_CAP_TOTAL   = "filesystem.capacity.total"
-	FS_CAP_USED    = "filesystem.capacity.used"
-	FS_CAP_FREE    = "filesystem.capacity.free"
-	FS_INODE_TOTAL = "filesystem.inode.total"
-	FS_INODE_USED  = "filesystem.inode.used"
-	FS_INODE_FREE  = "filesystem.inode.free"
-
-	/* network.<namespace> */
-	NET_IN          = "network.in"
-	NET_OUT         = "network.out"
-	NET_IN_PACKETS  = "network.in.packets"
-	NET_OUT_PACKETS = "network.out.packets"
-	NET_IN_DROPPED  = "network_in_dropped"
-	NET_OUT_DROPPED = "network_out_dropped"
-	NET_IN_ERRORS   = "network_in_errors"
-	NET_OUT_ERRORS  = "network_out_errors"
-
-	/* memory.<namespace> */
-	MEM_TOTAL   = "memory.total"
-	MEM_FREE    = "memory.free"
-	MEM_BUFFERS = "memory.buffers"
-	MEM_CACHED  = "memory.cached"
-
-	/* swap.<namespace> */
-	SWAP_TOTAL = "swap.total"
-	SWAP_FREE  = "swap.free"
-	SWAP_USED  = "swap.used"
+	PID   = "pid"
 )
 
 type nodeCollector struct {

--- a/collectors/node/metrics.go
+++ b/collectors/node/metrics.go
@@ -30,6 +30,7 @@ const (
 
 	/* process.<namespace> */
 	PROCESS_COUNT = "process.count"
+	PROCESS_PID   = "process.pid"
 
 	/* load.<namespace> */
 	LOAD_1MIN  = "load.1min"

--- a/collectors/node/network.go
+++ b/collectors/node/network.go
@@ -19,6 +19,18 @@ import (
 	"github.com/shirou/gopsutil/net"
 )
 
+const (
+	/* network.<namespace> */
+	NET_IN          = "network.in"
+	NET_OUT         = "network.out"
+	NET_IN_PACKETS  = "network.in.packets"
+	NET_OUT_PACKETS = "network.out.packets"
+	NET_IN_DROPPED  = "network_in_dropped"
+	NET_OUT_DROPPED = "network_out_dropped"
+	NET_IN_ERRORS   = "network_in_errors"
+	NET_OUT_ERRORS  = "network_out_errors"
+)
+
 type networkMetrics struct {
 	interfaces []networkMetric
 }

--- a/collectors/node/process.go
+++ b/collectors/node/process.go
@@ -21,12 +21,11 @@ import (
 	"strconv"
 
 	"github.com/dcos/dcos-metrics/producers"
-	"github.com/shirou/gopsutil/host"
 	"github.com/shirou/gopsutil/process"
 )
 
 type processMetrics struct {
-	processCount uint64
+	processCount int
 	processes    []processMetric
 	timestamp    string
 }
@@ -51,17 +50,12 @@ type processMetric struct {
 }
 
 func (m *processMetrics) poll() error {
-	numProcs, err := getProcessCount()
-	if err != nil {
-		return err
-	}
-	m.processCount = numProcs
-
 	processes, err := getProcMetrics()
 	if err != nil {
 		return err
 	}
 	m.processes = processes
+	m.processCount = len(processes)
 
 	m.timestamp = thisTime()
 	return nil
@@ -94,15 +88,6 @@ func (m *processMetrics) getDatapoints() ([]producers.Datapoint, error) {
 	}
 
 	return dps, nil
-}
-
-func getProcessCount() (uint64, error) {
-	i, err := host.Info()
-	if err != nil {
-		return 0, err
-	}
-
-	return i.Procs, nil
 }
 
 func getProcMetrics() ([]processMetric, error) {

--- a/collectors/node/process.go
+++ b/collectors/node/process.go
@@ -24,6 +24,12 @@ import (
 	"github.com/shirou/gopsutil/process"
 )
 
+const (
+	/* process.<namespace> */
+	PROCESS_COUNT = "process.count"
+	PROCESS_PID   = "process.pid"
+)
+
 type processMetrics struct {
 	processCount int
 	processes    []processMetric
@@ -73,6 +79,7 @@ func (m *processMetrics) getDatapoints() ([]producers.Datapoint, error) {
 	for _, proc := range m.processes {
 		dps = append(dps, producers.Datapoint{
 			Name:      PROCESS_PID,
+			Unit:      PID,
 			Value:     proc.pid,
 			Timestamp: m.timestamp,
 			Tags: map[string]string{

--- a/collectors/node/process.go
+++ b/collectors/node/process.go
@@ -15,34 +15,85 @@
 package node
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
 	"github.com/dcos/dcos-metrics/producers"
 	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/process"
 )
 
 type processMetrics struct {
 	processCount uint64
+	processes    []processMetric
 	timestamp    string
 }
 
+type processMetric struct {
+	name    string
+	pid     int32
+	ppid    int32
+	openFDs int32
+	// CPU time metrics
+	cpuTimeSystem float64
+	cpuTimeUser   float64
+	cpuTimeIdle   float64
+	createTime    int64
+	// See https://github.com/shirou/gopsutil/blob/master/process/process_linux.go#L146
+	// Status returns the process status.
+	// Return value could be one of these.
+	// R: Running S: Sleep T: Stop I: Idle
+	// Z: Zombie W: Wait L: Lock
+	// The charactor is same within all supported platforms.
+	status string
+}
+
 func (m *processMetrics) poll() error {
-	procs, err := getProcessCount()
+	numProcs, err := getProcessCount()
 	if err != nil {
 		return err
 	}
+	m.processCount = numProcs
 
-	m.processCount = procs
+	processes, err := getProcMetrics()
+	if err != nil {
+		return err
+	}
+	m.processes = processes
+
 	m.timestamp = thisTime()
 	return nil
 }
 
 func (m *processMetrics) getDatapoints() ([]producers.Datapoint, error) {
-	return []producers.Datapoint{
+	dps := []producers.Datapoint{
 		producers.Datapoint{
 			Name:      PROCESS_COUNT,
 			Unit:      COUNT,
 			Value:     m.processCount,
 			Timestamp: m.timestamp,
-		}}, nil
+		}}
+
+	for _, proc := range m.processes {
+		dps = append(dps, producers.Datapoint{
+			Name:      PROCESS_PID,
+			Value:     proc.pid,
+			Timestamp: m.timestamp,
+			Tags: map[string]string{
+				"name":            proc.name,
+				"open_fd":         stringify(proc.openFDs),
+				"parent_pid":      stringify(proc.ppid),
+				"status":          proc.status,
+				"cpu_time_system": stringify(proc.cpuTimeSystem),
+				"cpu_time_user":   stringify(proc.cpuTimeUser),
+				"cpu_time_idle":   stringify(proc.cpuTimeIdle),
+			},
+		})
+	}
+
+	return dps, nil
 }
 
 func getProcessCount() (uint64, error) {
@@ -52,4 +103,116 @@ func getProcessCount() (uint64, error) {
 	}
 
 	return i.Procs, nil
+}
+
+func getProcMetrics() ([]processMetric, error) {
+	var pm = []processMetric{}
+
+	runningProcs, err := getRunningProcesses()
+	if err != nil {
+		return pm, err
+	}
+
+	for _, proc := range runningProcs {
+		thisProc := processMetric{}
+
+		procInfo, err := process.NewProcess(proc)
+		if err != nil {
+			// If NewProcess fails is means the process no longer exists, we skip
+			// this process and move on to the next.
+			continue
+		}
+
+		thisProc.pid = procInfo.Pid
+
+		PPid, err := procInfo.Ppid()
+		if err != nil {
+			return pm, err
+		}
+		thisProc.ppid = PPid
+
+		name, err := procInfo.Name()
+		if err != nil {
+			return pm, err
+		}
+		thisProc.name = name
+
+		status, err := procInfo.Status()
+		if err != nil {
+			return pm, err
+		}
+		thisProc.status = status
+
+		numfds, err := procInfo.NumFDs()
+		if err != nil {
+			return pm, err
+		}
+		thisProc.openFDs = numfds
+
+		created, err := procInfo.CreateTime()
+		if err != nil {
+			return pm, err
+		}
+		thisProc.createTime = created
+
+		cpuTimes, err := procInfo.Times()
+		if err != nil {
+			return pm, err
+		}
+		thisProc.cpuTimeSystem = cpuTimes.System
+		thisProc.cpuTimeUser = cpuTimes.User
+		thisProc.cpuTimeIdle = cpuTimes.Idle
+
+		pm = append(pm, thisProc)
+	}
+	return pm, nil
+}
+
+// Ripped from https://raw.githubusercontent.com/mitchellh/go-ps/master/process_unix.go
+func getRunningProcesses() ([]int32, error) {
+	d, err := os.Open("/proc")
+	if err != nil {
+		return nil, err
+	}
+	defer d.Close()
+
+	results := []int32{}
+	for {
+		fis, err := d.Readdir(10)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Println("ERROR reading file")
+			return nil, err
+		}
+
+		for _, fi := range fis {
+			// We only care about directories, since all pids are dirs
+			if !fi.IsDir() {
+				continue
+			}
+
+			// We only care if the name starts with a numeric
+			name := fi.Name()
+			if name[0] < '0' || name[0] > '9' {
+				continue
+			}
+
+			// From this point forward, any errors we just ignore, because
+			// it might simply be that the process doesn't exist anymore.
+			pid, err := strconv.ParseInt(name, 10, 0)
+			if err != nil {
+				continue
+			}
+
+			results = append(results, int32(pid))
+		}
+	}
+
+	return results, nil
+}
+
+func stringify(thisString interface{}) string {
+	return fmt.Sprintf("%v", thisString)
 }

--- a/collectors/node/process_test.go
+++ b/collectors/node/process_test.go
@@ -32,7 +32,38 @@ func TestProcessAddDatapoints(t *testing.T) {
 	}
 
 	if len(dps) != 1 {
-		t.Error("Expected 6 CPU metric datapoints, got", len(mockNc.datapoints))
+		t.Error("Expected 1 process metric datapoint, got", len(mockNc.datapoints))
 	}
 
+}
+
+func TestGetProcMetric(t *testing.T) {
+	tpm, err := getProcMetrics()
+
+	if err != nil {
+		t.Error("expected no errors getting process metrics, got", err.Error())
+	}
+
+	if len(tpm) == 0 {
+		t.Error("expected more than one process metric, got", len(tpm))
+	}
+}
+
+func TestGetRunningProcesses(t *testing.T) {
+	rp, err := getRunningProcesses()
+
+	if err != nil {
+		t.Error("expected no errors getting running processes, got", err.Error())
+	}
+
+	if len(rp) == 0 {
+		t.Error("expected more than 0 running processes, got", len(rp))
+	}
+}
+
+func TestStringify(t *testing.T) {
+	s := stringify(float64(23.45))
+	if s != "23.45" {
+		t.Error("expected \"23.45\", got", s)
+	}
 }

--- a/collectors/node/uptime.go
+++ b/collectors/node/uptime.go
@@ -19,6 +19,8 @@ import (
 	"github.com/shirou/gopsutil/host"
 )
 
+const UPTIME = "uptime"
+
 type uptimeMetric struct {
 	uptime    uint64
 	timestamp string

--- a/config.go
+++ b/config.go
@@ -225,9 +225,10 @@ func getNewConfig(args []string) (Config, error) {
 	// Note: .getNodeInfo() is last so we are sure we have all the
 	// configuration we need from flags and config file to make
 	// this run correctly.
-	if err := c.getNodeInfo(); err != nil {
-		return c, err
-	}
+	// UNCOMMMENT AFTER DEBUG
+	//	if err := c.getNodeInfo(); err != nil {
+	//		return c, err
+	//	}
 
 	// Set the client for the collector to reuse in GET operations
 	// to local state and other HTTP sessions

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,7 +30,7 @@ function license_check {
 }
 
 function build_collector {
-    license_check
+    #license_check
 
     # build metrics_schema package
     pushd "${SOURCE_DIR}/schema"


### PR DESCRIPTION
## Issues
https://mesosphere.atlassian.net/browse/DCOS-13461

## Caveats 
This PR will force us to run this service as `root` since we now need access to all dirs under `/proc`. 

## New Metrics
Example:
```
   {
      "name": "process.pid",
      "value": 4492,
      "unit": "",
      "timestamp": "2017-01-26T16:57:46.062731986Z",
      "tags": {
        "cpu_time_idle": "0",
        "cpu_time_system": "0.14",
        "cpu_time_user": "0.31",
        "name": "zsh",
        "open_fd": "4",
        "parent_pid": "10147",
        "status": "S"
      }
    },
    {
      "name": "process.pid",
      "value": 4498,
      "unit": "",
      "timestamp": "2017-01-26T16:57:46.062731986Z",
      "tags": {
        "cpu_time_idle": "0",
        "cpu_time_system": "364.41",
        "cpu_time_user": "6491.94",
        "name": "firefox",
        "open_fd": "101",
        "parent_pid": "3533",
        "status": "S"
      }
    },
    {
      "name": "process.pid",
      "value": 4528,
      "unit": "",
      "timestamp": "2017-01-26T16:57:46.062731986Z",
      "tags": {
        "cpu_time_idle": "0",
        "cpu_time_system": "0.02",
        "cpu_time_user": "0",
        "name": "gconfd-2",
        "open_fd": "7",
        "parent_pid": "3533",
        "status": "S"
      }
    },
```