### PR TITLE
Use agent state for framework principal 

### DIFF
--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -40,6 +40,7 @@ var (
 					"id": "5349f49b-68b3-4638-aab2-fc4ec845f993-0000",
 					"name": "marathon",
 					"role": "*",
+					"principal": "dcos_marathon",
 					"executors": [
 						{
 							"id": "foo.124b1048-a17a-11e6-9182-080027fb5b88",
@@ -289,9 +290,6 @@ func TestTransform(t *testing.T) {
 		// by the HTTP test server(s). So we need to unmarshal them here before
 		// they can be used by a.transform().
 		if err := json.Unmarshal(mockAgentState, &mac.agentState); err != nil {
-			panic(err)
-		}
-		if err := json.Unmarshal(mockClusterState, &mac.clusterState); err != nil {
 			panic(err)
 		}
 		if err := json.Unmarshal(mockContainerMetrics, &mac.containerMetrics); err != nil {


### PR DESCRIPTION
### Tickets
Calling master state creates to must master host load: https://mesosphere.atlassian.net/browse/DCOS-13688

and https://jira.mesosphere.com/browse/DCOS-13936

Since calling the master state is only used for retrieval of framework principal we have moved the framework principal to the agent state: https://issues.apache.org/jira/browse/MESOS-7071

This PR required Mesos 1.2 which includes this change https://reviews.apache.org/r/56359/ 