### PR TITLE
Remove Reflect Usage for Metric Names

### DIFF
--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -15,25 +15,23 @@
 package agent
 
 import (
-	"bytes"
-	"html/template"
 	"net"
 	"net/http"
-	"net/url"
-	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/dcos/dcos-metrics/collectors"
 	"github.com/dcos/dcos-metrics/producers"
-	"github.com/dcos/dcos-metrics/util/http/client"
 )
 
 const (
 	// HTTPTIMEOUT defines the maximum duration for all requests
 	HTTPTIMEOUT = 2 * time.Second
+
+	SECONDS = "seconds"
+	COUNT   = "count"
+	BYTES   = "bytes"
 )
 
 // Collector defines the collector type for Mesos agent. It is
@@ -58,96 +56,6 @@ type Collector struct {
 	metricsChan chan producers.MetricsMessage
 	nodeInfo    collectors.NodeInfo
 	timestamp   int64
-}
-
-// agentContainer defines the structure of the response expected from Mesos
-// *for a single container* when polling the '/containers' endpoint in API v1.
-// Note that agentContainer is actually in a top-level array. For more info, see
-// https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/agent/agent.proto#L161-L168
-type agentContainer struct {
-	FrameworkID     string                 `json:"framework_id"`
-	ExecutorID      string                 `json:"executor_id"`
-	ExecutorName    string                 `json:"executor_name"`
-	Source          string                 `json:"source"`
-	ContainerID     string                 `json:"container_id"`
-	ContainerStatus map[string]interface{} `json:"container_status"`
-	Statistics      *resourceStatistics    `json:"statistics"`
-}
-
-// agentState defines the structure of the response expected from Mesos
-// *for all cluster state* when polling the /state endpoint.
-// Specifically, this struct exists for the following purposes:
-//
-//   * collect labels from individual containers (executors) since labels are
-//     NOT available via the /containers endpoint in v1.
-//   * map framework IDs to a human-readable name
-//
-// For more information, see the upstream protobuf in Mesos v1:
-//
-//   * Framework info: https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L207-L307
-//   * Executor info:  https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L474-L522
-//
-type agentState struct {
-	ID         string          `json:"id"`
-	Hostname   string          `json:"hostname"`
-	Frameworks []frameworkInfo `json:"frameworks"`
-}
-
-type frameworkInfo struct {
-	ID        string         `json:"id"`
-	Name      string         `json:"name"`
-	Principal string         `json:"principal,omitempty"`
-	Role      string         `json:"role"`
-	Executors []executorInfo `json:"executors,omitempty"`
-}
-
-type executorInfo struct {
-	ID        string           `json:"id"`
-	Name      string           `json:"name"`
-	Container string           `json:"container"`
-	Labels    []executorLabels `json:"labels,omitempty"` // labels are optional
-}
-
-type executorLabels struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
-}
-
-// resourceStatistics defines the structure of the response expected from Mesos
-// when referring to container and/or executor metrics. In Mesos, the
-// ResourceStatistics message is very large; it defines many fields that are
-// dependent on a feature being enabled in Mesos, and not all of those features
-// are enabled in DC/OS.
-//
-// Therefore, we redefine the resourceStatistics struct here with only the fields
-// dcos-metrics currently cares about, which should be stable for Mesos API v1.
-//
-// For a complete reference, see:
-// https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L921-L1022
-type resourceStatistics struct {
-	// CPU usage info
-	CpusUserTimeSecs      float64 `json:"cpus_user_time_secs,omitempty"`
-	CpusSystemTimeSecs    float64 `json:"cpus_system_time_secs,omitempty"`
-	CpusLimit             float64 `json:"cpus_limit,omitempty"`
-	CpusThrottledTimeSecs float64 `json:"cpus_throttled_time_secs,omitempty"`
-
-	// Memory info
-	MemTotalBytes uint64 `json:"mem_total_bytes,omitempty"`
-	MemLimitBytes uint64 `json:"mem_limit_bytes,omitempty"`
-
-	// Disk info
-	DiskLimitBytes uint64 `json:"disk_limit_bytes,omitempty"`
-	DiskUsedBytes  uint64 `json:"disk_used_bytes,omitempty"`
-
-	// Network info
-	NetRxPackets uint64 `json:"net_rx_packets,omitempty"`
-	NetRxBytes   uint64 `json:"net_rx_bytes,omitempty"`
-	NetRxErrors  uint64 `json:"net_rx_errors,omitempty"`
-	NetRxDropped uint64 `json:"net_rx_dropped,omitempty"`
-	NetTxPackets uint64 `json:"net_tx_packets,omitempty"`
-	NetTxBytes   uint64 `json:"net_tx_bytes,omitempty"`
-	NetTxErrors  uint64 `json:"net_tx_errors,omitempty"`
-	NetTxDropped uint64 `json:"net_tx_dropped,omitempty"`
 }
 
 // New creates a new instance of the Mesos agent collector (poller).
@@ -182,42 +90,10 @@ func (c *Collector) pollMesosAgent() {
 		c.log.Errorf("Failed to get agent state from %s. Error: %s", host, err)
 	}
 
-	c.log.Debugf("Fetching container metrics from DC/OS host %s", host)
+	c.log.Debugf("Fetching container metrics from host %s", host)
 	if err := c.getContainerMetrics(); err != nil {
 		c.log.Errorf("Failed to get container metrics from %s. Error: %s", host, err)
 	}
-}
-
-// getContainerMetrics queries an agent for container-level metrics, such as
-// CPU, memory, disk, and network usage.
-func (c *Collector) getContainerMetrics() error {
-	c.containerMetrics = []agentContainer{}
-	u := url.URL{
-		Scheme: c.RequestProtocol,
-		Host:   net.JoinHostPort(c.nodeInfo.IPAddress, strconv.Itoa(c.Port)),
-		Path:   "/containers",
-	}
-
-	c.HTTPClient.Timeout = HTTPTIMEOUT
-
-	return client.Fetch(c.HTTPClient, u, &c.containerMetrics)
-}
-
-// getAgentState fetches the state JSON from the Mesos agent, which contains
-// info such as framework names and IDs, the current leader, config flags,
-// container (executor) labels, and more.
-func (c *Collector) getAgentState() error {
-	c.agentState = agentState{}
-
-	u := url.URL{
-		Scheme: c.RequestProtocol,
-		Host:   net.JoinHostPort(c.nodeInfo.IPAddress, strconv.Itoa(c.Port)),
-		Path:   "/state",
-	}
-
-	c.HTTPClient.Timeout = HTTPTIMEOUT
-
-	return client.Fetch(c.HTTPClient, u, &c.agentState)
 }
 
 func (c *Collector) transformContainerMetrics() (out []producers.MetricsMessage) {
@@ -228,7 +104,7 @@ func (c *Collector) transformContainerMetrics() (out []producers.MetricsMessage)
 	for _, cm := range c.containerMetrics {
 		msg = producers.MetricsMessage{
 			Name:       producers.ContainerMetricPrefix,
-			Datapoints: c.buildDatapoints(cm, t),
+			Datapoints: c.createDatapoints(),
 			Timestamp:  t.UTC().Unix(),
 		}
 
@@ -281,70 +157,4 @@ func getLabelsByContainerID(containerID string, frameworks []frameworkInfo) map[
 		}
 	}
 	return labels
-}
-
-// buildDatapoints takes an incoming structure and builds Datapoints
-// for a MetricsMessage. It uses a normalized version of the JSON tag
-// as the datapoint name.
-func (c *Collector) buildDatapoints(in interface{}, t time.Time) []producers.Datapoint {
-	pts := []producers.Datapoint{}
-	v := reflect.Indirect(reflect.ValueOf(in))
-
-	for i := 0; i < v.NumField(); i++ { // Iterate over fields in the struct
-		f := v.Field(i)
-		typ := v.Type().Field(i)
-
-		switch f.Kind() { // Handle nested data
-		case reflect.Ptr:
-			pts = append(pts, c.buildDatapoints(f.Elem().Interface(), t)...)
-			continue
-		case reflect.Map:
-			// Ignore maps when building datapoints
-			continue
-		case reflect.Slice:
-			for j := 0; j < f.Len(); j++ {
-				for _, ndp := range c.buildDatapoints(f.Index(j).Interface(), t) {
-					pts = append(pts, ndp)
-				}
-			}
-			continue
-		case reflect.Struct:
-			pts = append(pts, c.buildDatapoints(f.Interface(), t)...)
-			continue
-		}
-
-		// Get the underlying value; see https://golang.org/pkg/reflect/#Kind
-		var uv interface{}
-		switch f.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			uv = f.Int()
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			uv = f.Uint()
-		case reflect.Float32, reflect.Float64:
-			uv = f.Float()
-		case reflect.String:
-			continue // strings aren't valid values for our metrics
-		}
-
-		// Parse JSON name (with or without templating)
-		var parsed bytes.Buffer
-		jsonName := strings.Join([]string{strings.Split(typ.Tag.Get("json"), ",")[0]}, producers.MetricNamespaceSep)
-		tmpl, err := template.New("_nodeMetricName").Parse(jsonName)
-		if err != nil {
-			c.log.Warn("Unable to build datapoint for metric with name %s, skipping", jsonName)
-			continue
-		}
-		if err := tmpl.Execute(&parsed, v.Interface()); err != nil {
-			c.log.Warn("Unable to build datapoint for metric with name %s, skipping", jsonName)
-			continue
-		}
-
-		pts = append(pts, producers.Datapoint{
-			Name:      parsed.String(),
-			Unit:      "", // TODO(roger): not currently an easy way to get units
-			Value:     uv,
-			Timestamp: t.UTC().Format(time.RFC3339Nano),
-		})
-	}
-	return pts
 }

--- a/collectors/mesos/agent/container.go
+++ b/collectors/mesos/agent/container.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/dcos/dcos-metrics/util/http/client"
+)
+
+// agentContainer defines the structure of the response expected from Mesos
+// *for a single container* when polling the '/containers' endpoint in API v1.
+// Note that agentContainer is actually in a top-level array. For more info, see
+// https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/agent/agent.proto#L161-L168
+type agentContainer struct {
+	FrameworkID     string                 `json:"framework_id"`
+	ExecutorID      string                 `json:"executor_id"`
+	ExecutorName    string                 `json:"executor_name"`
+	Source          string                 `json:"source"`
+	ContainerID     string                 `json:"container_id"`
+	ContainerStatus map[string]interface{} `json:"container_status"`
+	Statistics      *resourceStatistics    `json:"statistics"`
+}
+
+// resourceStatistics defines the structure of the response expected from Mesos
+// when referring to container and/or executor metrics. In Mesos, the
+// ResourceStatistics message is very large; it defines many fields that are
+// dependent on a feature being enabled in Mesos, and not all of those features
+// are enabled in DC/OS.
+//
+// Therefore, we redefine the resourceStatistics struct here with only the fields
+// dcos-metrics currently cares about, which should be stable for Mesos API v1.
+//
+// For a complete reference, see:
+// https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L921-L1022
+type resourceStatistics struct {
+	// CPU usage info
+	CpusUserTimeSecs      float64 `json:"cpus_user_time_secs,omitempty"`
+	CpusSystemTimeSecs    float64 `json:"cpus_system_time_secs,omitempty"`
+	CpusLimit             float64 `json:"cpus_limit,omitempty"`
+	CpusThrottledTimeSecs float64 `json:"cpus_throttled_time_secs,omitempty"`
+
+	// Memory info
+	MemTotalBytes uint64 `json:"mem_total_bytes,omitempty"`
+	MemLimitBytes uint64 `json:"mem_limit_bytes,omitempty"`
+
+	// Disk info
+	DiskLimitBytes uint64 `json:"disk_limit_bytes,omitempty"`
+	DiskUsedBytes  uint64 `json:"disk_used_bytes,omitempty"`
+
+	// Network info
+	NetRxPackets uint64 `json:"net_rx_packets,omitempty"`
+	NetRxBytes   uint64 `json:"net_rx_bytes,omitempty"`
+	NetRxErrors  uint64 `json:"net_rx_errors,omitempty"`
+	NetRxDropped uint64 `json:"net_rx_dropped,omitempty"`
+	NetTxPackets uint64 `json:"net_tx_packets,omitempty"`
+	NetTxBytes   uint64 `json:"net_tx_bytes,omitempty"`
+	NetTxErrors  uint64 `json:"net_tx_errors,omitempty"`
+	NetTxDropped uint64 `json:"net_tx_dropped,omitempty"`
+}
+
+// poll queries an agent for container-level metrics, such as
+// CPU, memory, disk, and network usage.
+func (c *Collector) getContainerMetrics() error {
+	u := url.URL{
+		Scheme: c.RequestProtocol,
+		Host:   net.JoinHostPort(c.nodeInfo.IPAddress, strconv.Itoa(c.Port)),
+		Path:   "/containers",
+	}
+
+	c.HTTPClient.Timeout = HTTPTIMEOUT
+
+	return client.Fetch(c.HTTPClient, u, &c.containerMetrics)
+}

--- a/collectors/mesos/agent/container.go
+++ b/collectors/mesos/agent/container.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (

--- a/collectors/mesos/agent/metrics.go
+++ b/collectors/mesos/agent/metrics.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"time"
+
+	"github.com/dcos/dcos-metrics/producers"
+)
+
+func (c *Collector) createDatapoints() []producers.Datapoint {
+	ts := thisTime()
+	dps := []producers.Datapoint{}
+	for _, container := range c.containerMetrics {
+		addDps := []producers.Datapoint{
+			producers.Datapoint{
+				Name:      "cpus.user.time",
+				Value:     container.Statistics.CpusUserTimeSecs,
+				Unit:      SECONDS,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "cpus.system.time",
+				Value:     container.Statistics.CpusSystemTimeSecs,
+				Unit:      SECONDS,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "cpus.limit",
+				Value:     container.Statistics.CpusLimit,
+				Unit:      COUNT,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "cpus.throttled.time",
+				Value:     container.Statistics.CpusThrottledTimeSecs,
+				Unit:      SECONDS,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "mem.total",
+				Value:     container.Statistics.MemTotalBytes,
+				Unit:      BYTES,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "mem.limit",
+				Value:     container.Statistics.MemLimitBytes,
+				Unit:      BYTES,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "disk.limit",
+				Value:     container.Statistics.DiskLimitBytes,
+				Unit:      BYTES,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "disk.used",
+				Value:     container.Statistics.DiskUsedBytes,
+				Unit:      BYTES,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.rx.packets",
+				Value:     container.Statistics.NetRxPackets,
+				Unit:      COUNT,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.rx.bytes",
+				Value:     container.Statistics.NetRxBytes,
+				Unit:      BYTES,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.rx.errors",
+				Value:     container.Statistics.NetRxErrors,
+				Unit:      COUNT,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.rx.dropped",
+				Value:     container.Statistics.NetRxDropped,
+				Unit:      COUNT,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.tx.packets",
+				Value:     container.Statistics.NetRxPackets,
+				Unit:      COUNT,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.tx.bytes",
+				Value:     container.Statistics.NetRxBytes,
+				Unit:      BYTES,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.tx.errors",
+				Value:     container.Statistics.NetRxErrors,
+				Unit:      COUNT,
+				Timestamp: ts,
+			},
+			producers.Datapoint{
+				Name:      "net.tx.dropped",
+				Value:     container.Statistics.NetRxDropped,
+				Unit:      COUNT,
+				Timestamp: ts,
+			},
+		}
+
+		for _, dp := range addDps {
+			dps = append(dps, dp)
+		}
+	}
+
+	return dps
+}
+
+// -- helpers
+
+func thisTime() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}

--- a/collectors/mesos/agent/metrics.go
+++ b/collectors/mesos/agent/metrics.go
@@ -20,110 +20,137 @@ import (
 	"github.com/dcos/dcos-metrics/producers"
 )
 
-func (c *Collector) createDatapoints() []producers.Datapoint {
+const (
+	// Container tagging constants
+	CONTAINERID  = "container_id"
+	SOURCE       = "source"
+	FRAMEWORKID  = "framework_id"
+	EXECUTORID   = "executor_id"
+	EXECUTORNAME = "executor_name"
+
+	// Container unit constants
+	SECONDS = "seconds"
+	COUNT   = "count"
+	BYTES   = "bytes"
+)
+
+func (c *Collector) createContainerDatapoints() []producers.Datapoint {
 	ts := thisTime()
 	dps := []producers.Datapoint{}
+
 	for _, container := range c.containerMetrics {
+
+		dpTags := map[string]string{
+			CONTAINERID:  container.ContainerID,
+			SOURCE:       container.Source,
+			FRAMEWORKID:  container.FrameworkID,
+			EXECUTORID:   container.ExecutorID,
+			EXECUTORNAME: container.ExecutorName,
+		}
+
+		c.log.Debugf("Adding tags for container %s:\n%+v", container.ContainerID, dpTags)
+
 		addDps := []producers.Datapoint{
 			producers.Datapoint{
-				Name:      "cpus.user.time",
-				Value:     container.Statistics.CpusUserTimeSecs,
-				Unit:      SECONDS,
-				Timestamp: ts,
+				Name:  "cpus.user.time",
+				Value: container.Statistics.CpusUserTimeSecs,
+				Unit:  SECONDS,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "cpus.system.time",
-				Value:     container.Statistics.CpusSystemTimeSecs,
-				Unit:      SECONDS,
-				Timestamp: ts,
+				Name:  "cpus.system.time",
+				Value: container.Statistics.CpusSystemTimeSecs,
+				Unit:  SECONDS,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "cpus.limit",
-				Value:     container.Statistics.CpusLimit,
-				Unit:      COUNT,
-				Timestamp: ts,
+				Name:  "cpus.limit",
+				Value: container.Statistics.CpusLimit,
+				Unit:  COUNT,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "cpus.throttled.time",
-				Value:     container.Statistics.CpusThrottledTimeSecs,
-				Unit:      SECONDS,
-				Timestamp: ts,
+				Name:  "cpus.throttled.time",
+				Value: container.Statistics.CpusThrottledTimeSecs,
+				Unit:  SECONDS,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "mem.total",
-				Value:     container.Statistics.MemTotalBytes,
-				Unit:      BYTES,
-				Timestamp: ts,
+				Name:  "mem.total",
+				Value: container.Statistics.MemTotalBytes,
+				Unit:  BYTES,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "mem.limit",
-				Value:     container.Statistics.MemLimitBytes,
-				Unit:      BYTES,
-				Timestamp: ts,
+				Name:  "mem.limit",
+				Value: container.Statistics.MemLimitBytes,
+				Unit:  BYTES,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "disk.limit",
-				Value:     container.Statistics.DiskLimitBytes,
-				Unit:      BYTES,
-				Timestamp: ts,
+				Name:  "disk.limit",
+				Value: container.Statistics.DiskLimitBytes,
+				Unit:  BYTES,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "disk.used",
-				Value:     container.Statistics.DiskUsedBytes,
-				Unit:      BYTES,
-				Timestamp: ts,
+				Name:  "disk.used",
+				Value: container.Statistics.DiskUsedBytes,
+				Unit:  BYTES,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.rx.packets",
-				Value:     container.Statistics.NetRxPackets,
-				Unit:      COUNT,
-				Timestamp: ts,
+				Name:  "net.rx.packets",
+				Value: container.Statistics.NetRxPackets,
+				Unit:  COUNT,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.rx.bytes",
-				Value:     container.Statistics.NetRxBytes,
-				Unit:      BYTES,
-				Timestamp: ts,
+				Name:  "net.rx.bytes",
+				Value: container.Statistics.NetRxBytes,
+				Unit:  BYTES,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.rx.errors",
-				Value:     container.Statistics.NetRxErrors,
-				Unit:      COUNT,
-				Timestamp: ts,
+				Name:  "net.rx.errors",
+				Value: container.Statistics.NetRxErrors,
+				Unit:  COUNT,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.rx.dropped",
-				Value:     container.Statistics.NetRxDropped,
-				Unit:      COUNT,
-				Timestamp: ts,
+				Name:  "net.rx.dropped",
+				Value: container.Statistics.NetRxDropped,
+				Unit:  COUNT,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.tx.packets",
-				Value:     container.Statistics.NetRxPackets,
-				Unit:      COUNT,
-				Timestamp: ts,
+				Name:  "net.tx.packets",
+				Value: container.Statistics.NetRxPackets,
+				Unit:  COUNT,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.tx.bytes",
-				Value:     container.Statistics.NetRxBytes,
-				Unit:      BYTES,
-				Timestamp: ts,
+				Name:  "net.tx.bytes",
+				Value: container.Statistics.NetRxBytes,
+				Unit:  BYTES,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.tx.errors",
-				Value:     container.Statistics.NetRxErrors,
-				Unit:      COUNT,
-				Timestamp: ts,
+				Name:  "net.tx.errors",
+				Value: container.Statistics.NetRxErrors,
+				Unit:  COUNT,
+				Tags:  dpTags,
 			},
 			producers.Datapoint{
-				Name:      "net.tx.dropped",
-				Value:     container.Statistics.NetRxDropped,
-				Unit:      COUNT,
-				Timestamp: ts,
+				Name:  "net.tx.dropped",
+				Value: container.Statistics.NetRxDropped,
+				Unit:  COUNT,
+				Tags:  dpTags,
 			},
 		}
 
 		for _, dp := range addDps {
+			dp.Timestamp = ts
 			dps = append(dps, dp)
 		}
 	}

--- a/collectors/mesos/agent/metrics.go
+++ b/collectors/mesos/agent/metrics.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/dcos/dcos-metrics/util/http/client"
+)
+
+// agentState defines the structure of the response expected from Mesos
+// *for all cluster state* when polling the /state endpoint.
+// Specifically, this struct exists for the following purposes:
+//
+//   * collect labels from individual containers (executors) since labels are
+//     NOT available via the /containers endpoint in v1.
+//   * map framework IDs to a human-readable name
+//
+// For more information, see the upstream protobuf in Mesos v1:
+//
+//   * Framework info: https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L207-L307
+//   * Executor info:  https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L474-L522
+//
+type agentState struct {
+	ID         string          `json:"id"`
+	Hostname   string          `json:"hostname"`
+	Frameworks []frameworkInfo `json:"frameworks"`
+}
+
+type frameworkInfo struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Principal string         `json:"principal,omitempty"`
+	Role      string         `json:"role"`
+	Executors []executorInfo `json:"executors,omitempty"`
+}
+
+type executorInfo struct {
+	ID        string           `json:"id"`
+	Name      string           `json:"name"`
+	Container string           `json:"container"`
+	Labels    []executorLabels `json:"labels,omitempty"` // labels are optional
+}
+
+type executorLabels struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// getAgentState fetches the state JSON from the Mesos agent, which contains
+// info such as framework names and IDs, the current leader, config flags,
+// container (executor) labels, and more.
+func (c *Collector) getAgentState() error {
+	c.agentState = agentState{}
+
+	u := url.URL{
+		Scheme: c.RequestProtocol,
+		Host:   net.JoinHostPort(c.nodeInfo.IPAddress, strconv.Itoa(c.Port)),
+		Path:   "/state",
+	}
+
+	c.HTTPClient.Timeout = HTTPTIMEOUT
+
+	return client.Fetch(c.HTTPClient, u, &c.agentState)
+}

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -1,3 +1,17 @@
+// Copyright 2016 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package agent
 
 import (

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -84,6 +84,8 @@ func containerHandler(p *producerImpl) http.HandlerFunc {
 			return
 		}
 
+		httpLog.Debugf("Encoding container metrics:\n%+v", containerMetrics)
+
 		encode(containerMetrics, w)
 	}
 }


### PR DESCRIPTION
Fixes issues in DCOS-13945 and:
- [x] Remove abusive reflect usage for deriving datapoints
- [x] Add tagging to container metrics
- [x] Add unit values to container metrics