### PR TITLE
Update DC/OS JIRA URLs to jira.mesosphere.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ If you're new to Go, you might also find the [Effective Go][effective-go] docume
   * Update any outstanding tickets (if applicable) to mention that you've submitted a change,
   and provide a link to the pull request.
 
-[dcos-jira]: https://dcosjira.atlassian.net
+[dcos-jira]: https://jira.mesosphere.com
 [dcos-metrics-github]: https://github.com/dcos/dcos-metrics
 [dcos-metrics-readme]: README.md
 [effective-go]: https://golang.org/doc/effective_go.html

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ have a chance to keep up with community contributions, please follow the guideli
   * Original author: [Nicholas Parker][github-nickbp]
 
 
-[dcos-jira]: https://dcosjira.atlassian.net
+[dcos-jira]: https://jira.mesosphere.com
 [dcos-mailing-list]: https://groups.google.com/a/dcos.io/forum/#!forum/users
 [dcos-slack]: https://dcos-community.slack.com
 [github-dcos]: https://github.com/dcos/dcos


### PR DESCRIPTION
The DC/OS JIRA URL changed recently. This PR updated references to it in our docs. 