### PR TITLE
Guard percentage format helper to avoid divide-by-0

### DIFF
--- a/collectors/node/cpu.go
+++ b/collectors/node/cpu.go
@@ -144,9 +144,6 @@ func getCPUTimes() (cpu.TimesStat, cpu.TimesStat, error) {
 // calculatePct returns the percent utilization for CPU states. 100.00 => 100.00%
 func calculatePcts(lastTimes cpu.TimesStat, curTimes cpu.TimesStat) cpu.TimesStat {
 	totalDelta := curTimes.Total() - lastTimes.Total()
-	if totalDelta == 0 {
-		totalDelta = 1 // can't divide by zero
-	}
 	return cpu.TimesStat{
 		User:      formatPct(curTimes.User-lastTimes.User, totalDelta),
 		System:    formatPct(curTimes.System-lastTimes.System, totalDelta),
@@ -164,6 +161,10 @@ func calculatePcts(lastTimes cpu.TimesStat, curTimes cpu.TimesStat) cpu.TimesSta
 
 // Helper function: derives percentage, rounds to 2dp and sanitises
 func formatPct(f float64, div float64) float64 {
+	// avoid division by 0
+	if div == 0 {
+		div = 1
+	}
 	rounded := math.Floor((f / div * 10000) + .5)
 	return math.Max(rounded/100, 0)
 }

--- a/collectors/node/cpu_test.go
+++ b/collectors/node/cpu_test.go
@@ -127,6 +127,9 @@ func TestFormatPct(t *testing.T) {
 				So(formatPct(tc.input, 100), ShouldEqual, tc.expected)
 			}
 		})
+		Convey("Should ignore attempts to divide by 0", func() {
+			So(formatPct(0.01, 0), ShouldEqual, 1)
+		})
 	})
 }
 


### PR DESCRIPTION
This PR addresses feedback from @darkonie in #67, moving a divide-by-0 guard into the `formatPct` function. 