### PR TITLE
General plugin fixes and Datadog-specific fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	bash -c "./scripts/build.sh statsd-emitter"
 
 plugin:
-	bash -c "./scripts/build.sh datadog_plugin"
+	bash -c "./scripts/build.sh plugins"
 
 test:
 	bash -c "./scripts/test.sh collector unit"

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,7 +1,7 @@
 ## DC/OS Metrics Service Plugins
 **NOTE** These plugins are considered experimental and are not supported by the DC/OS support team. If you're having issues, please feel free to file an issue to this repo (not github.com/dcos/dcos) or file a *Pull Request* (we love pull requests!).
 
-Though your mileage may vary, if there is a plugin missing that you need, please feel free to file an issue so we can poll what services our users want the most. 
+Though your mileage may vary, if there is a plugin missing that you need, please feel free to file an issue so we can poll what services our users want the most.
 
 ## Developing
 To develop a new plugin in preparation for a pull requet to this project:
@@ -14,24 +14,12 @@ To develop a new plugin in preparation for a pull requet to this project:
 1. Create flags: `myFalgs := []cli.Flag{}`
 1. `myPlugin := plugin.New(myFlags)` -> `plugin.Plugin{}`
 1. Use `myPlugin.App.Action` and pass it a [cli.ActionFunc()](https://github.com/urfave/cli/blob/master/app.go#L66) which has all the `main()` logic your plugin needs.
-1. Call `myPlugin.Metrics()` which returns a slice of `producers.MetricsMessage{}` from the metrics HTTP API. 
+1. Call `myPlugin.Metrics()` which returns a slice of `producers.MetricsMessage{}` from the metrics HTTP API.
 
-At this point you can write what ever helper methods you need to transform these and send to your metrics aggregation or cloud hosted service. 
+At this point you can write what ever helper methods you need to transform these and send to your metrics aggregation or cloud hosted service.
 
 ### Unit Test Coverage
 1. Add a unit test (aim for 80% coverage)
-
-### Add Plugin to Build Pipeline
-#### Add `cool` plugin to the build pipeline
-```
-vi Makefile
-# add a line to build your plugin from scripts/build.sh - follow the already shown 
-pattern for this.
-
-vi scripts.build.sh
-# add in a function() for building your plugin. Follow the patterns in this script for 
-adding your function.
-```
 
 #### Add a README.md in your `cool` package explaining:
 ```
@@ -44,7 +32,7 @@ This cool plugin allows you to plugin to cool stuff.
 
 # Caveats
 I knew there were caveats!
-``` 
+```
 
-#### Submit a Pull Request! 
+#### Submit a Pull Request!
 Ping @malnick on DC/OS community slack :)

--- a/plugins/datadog/README.md
+++ b/plugins/datadog/README.md
@@ -2,6 +2,7 @@
 This plugin supports sending metrics from the DC/OS metrics service on both master and agent hosts to a datadog agent for shipping to DatadogHQ.
 
 ## Installation
+
 ### Build this plugin (requires a Golang environment)
 1. `git clone git@github.com:dcos/dcos-metrics`
 1. `cd dcos-metrics && make`
@@ -12,31 +13,46 @@ Plugin is available in the build directory:
 build
 ├── collector
 │   └── dcos-metrics-collector-1.0.0-rc7
-├── datadog_plugin
+├── plugins
 │   └── dcos-metrics-datadog_plugin-1.0.0-rc7
 └── statsd-emitter
     └── dcos-metrics-statsd-emitter-1.0.0-rc7
 ```
 
 ### Install the datadog agent in your cluster
-Checkout your [Datadog account](https://app.datadoghq.com/account) for more info on getting and installing agent's for your specific OS. 
+Install the `datadog` package in DC/OS:
+- Visit `https://YOURCLUSTER.COM/universe/packages`
+- Click the INSTALL button for the `datadog` package.
+- Go into ADVANCED INSTALLATION and fill in [your datadog API_KEY](https://app.datadoghq.com/account/settings#api).
+- After filling in the API_KEY, install the package by clicking REVIEW AND INSTALL then INSTALL.
 
-For example sake, here's the one we used to test this project on CoreOS:
+After a minute or two a datadog agent will be running in the cluster at `datadog-agent.marathon.mesos:8125`. This is the default location used by the datadog plugin.
+
+### Test the DC/OS datadog metrics plugin (agents only)
+As a stopgap during testing, you may be able to manually run the datadog plugin on your agents by running it as a Marathon task. You must first upload the binary you built to a web server that's visible to your cluster, then create a Marathon application like the following (with customized `cmd`, `instances`, and `uris` to meet your needs):
+
 ```
-docker run -d --name dd-agent -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e SD_BACKEND=docker -e API_KEY=0399e2d327848d3317d15d47dcf40461 datadog/docker-dd-agent:latest
+{
+  "cmd": "chmod +x ./dcos-metrics-* && ./dcos-metrics-* -dcos-role agent -auth-token <CONTENT OF 'dcos config show core.dcos_acs_token'>",
+  "instances": NUMBER_OF_AGENTS,
+  "uris": [ "https://YOURFILEHOST.COM/dcos-metrics-datadog_plugin-YOURBUILDVERSION" ],
+  "id": "test-datadog-plugin",
+  "cpus": 0.1,
+  "mem": 128,
+  "disk": 0,
+  "acceptedResourceRoles": [ "slave_public", "*" ]
+}
 ```
 
-Note in testing, we had to add `-p 8125/8125/udp` to the `docker run` command in order to proxy the container port for UDP access. 
-
-### Install the DC/PS datadog metrics plugin
-For each host in your cluster, you'll need to transfer the binary you build for the plugin and then add a systemd unit to manage the service. This unit differs slightly between agent and master hosts.
+### Install the DC/OS datadog metrics plugin
+Once you're happy with the result, you'll need to install the plugin into your cluster. For each host in your cluster, you'll need to transfer the binary you build for the plugin and then add a systemd unit to manage the service. This unit differs slightly between agent and master hosts.
 
 #### Create a Valid Auth Token for DC/OS
 The DC/OS docs have good info on making this auth token for [OSS](https://dcos.io/docs/1.7/administration/id-and-access-mgt/managing-authentication/) and [enterprise](https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/) DC/OS.
 
 #### Deploy the Metrics Plugin to Every Cluster Host
 1. `scp dcos-metrics-datadog-plugin-1.0.0-rc7 my.host:/usr/bin`
-1. `ssh my.master "chmod 0755 /usr/bin/dcos-metrics-datadog-plugin-1.0.0-rc7"` 
+1. `ssh my.master "chmod 0755 /usr/bin/dcos-metrics-datadog-plugin-1.0.0-rc7"`
 
 #### Master Systemd Unit
 Add a master systemd unit file: `cat /etc/systemd/system/dcos-metrics-datadog-plugin.service`

--- a/plugins/datadog/datadog.go
+++ b/plugins/datadog/datadog.go
@@ -36,13 +36,13 @@ func main() {
 	ddPluginFlags := []cli.Flag{
 		cli.StringFlag{
 			Name:  "datadog-host",
-			Value: "localhost",
-			Usage: "Datadog URL to query",
+			Value: "datadog-agent.marathon.mesos",
+			Usage: "Datadog output hostname",
 		},
 		cli.StringFlag{
 			Name:  "datadog-port",
 			Value: "8125",
-			Usage: "Datadog port",
+			Usage: "Datadog output UDP port",
 		},
 	}
 
@@ -123,22 +123,21 @@ func buildTags(msg producers.Dimensions) (tags []string, err error) {
 		// map[string]string for user-defined Labels
 		if v.Field(i).Kind() == reflect.Map {
 			for k, v := range v.Field(i).Interface().(map[string]string) {
-				tags = append(tags, strings.Join([]string{k, v}, "."))
+				tags = append(tags, strings.Join([]string{k, v}, ":"))
 			}
 			continue
 		}
 
 		fieldInfo := v.Type().Field(i)
-		fieldTag := strings.Split(fieldInfo.Tag.Get("json"), ",")[0] // remove "omitempty" if present
-		fieldVal := fmt.Sprintf("%v", v.Field(i).Interface())
 
+		fieldVal := fmt.Sprintf("%v", v.Field(i).Interface())
 		if fieldVal == reflect.Zero(fieldInfo.Type).String() {
 			// don't include keys without a value
 			continue
 		}
 
-		tag := strings.Join([]string{fieldTag, fieldVal}, ".")
-		tags = append(tags, tag)
+		fieldTag := strings.Split(fieldInfo.Tag.Get("json"), ",")[0] // remove "omitempty" if present
+		tags = append(tags, strings.Join([]string{fieldTag, fieldVal}, ":"))
 	}
 
 	return tags, nil

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -163,6 +163,7 @@ func (p *Plugin) setEndpoints() error {
 
 	return errors.New("Role must be either 'master' or 'agent'")
 }
+
 func makeMetricsRequest(request *http.Request) (producers.MetricsMessage, error) {
 	logrus.Infof("Making request to %+v", request.URL)
 	client := &http.Client{}
@@ -182,7 +183,7 @@ func makeMetricsRequest(request *http.Request) (producers.MetricsMessage, error)
 
 	err = json.Unmarshal(body, &mm)
 	if err != nil {
-		logrus.Errorf("Encountered error parsing JSON, %s", err.Error())
+		logrus.Errorf("Encountered error parsing JSON, %s. JSON Content was: %s", err.Error(), body)
 		return mm, err
 	}
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,11 +47,14 @@ function build_statsd-emitter {
     examples/statsd-emitter/main.go
 }
 
-function build_datadog_plugin {
+function build_plugins {
     license_check
-    go build -a -o ${BUILD_DIR}/dcos-metrics-${COMPONENT}-${GIT_REF} \
-    -ldflags "-X github.com/dcos/dcos-metrics/plugins.VERSION=${VERSION}" \
-    plugins/datadog/datadog.go
+    for PLUGIN in $(cd plugins/ && ls -d */ | sed 's,/,,'); do
+        echo "Building plugin: $PLUGIN"
+        go build -a -o ${BUILD_DIR}/dcos-metrics-${PLUGIN}_plugin-${GIT_REF} \
+           -ldflags "-X github.com/dcos/dcos-metrics/plugins.VERSION=${VERSION}" \
+           plugins/${PLUGIN}/*.go
+    done
 }
 
 function main {
@@ -59,7 +62,9 @@ function main {
     BUILD_DIR="${SOURCE_DIR}/build/${COMPONENT}"
 
     build_${COMPONENT} ${BUILD_DIR}
-    tree build/
+    if [ -n "$(which tree)" ]; then
+        tree build/
+    fi
 }
 
 main "$@"


### PR DESCRIPTION
General plugin fixes:
- Single `plugins` build component to build *all* plugins. Artifacts are put into common `build/plugins/`.
- Include JSON content in log message when parsing fails.

Datadog plugin fixes:
- Fix tag construction: `key:val`
- Add instructions for setting up the (official?) `datadog-agent` package.
- Set default `-datadog-host` to the URL of the `datadog-agent` package.
- Add instructions for launching the datadog plugin as a marathon app on agents for testing.