### PR TITLE
Created Dockerfile that can be used to run the build.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,13 @@ like contributors to follow.
 If you have any questions on the below guidelines, please feel free to contact us by using
 any of the community resources listed in this project's [README.md][dcos-metrics-readme] file.
 
+## Building
+
+A Makefile is included with the project.
+
+If you are not running on Linux, a Dockerfile is also included that will be
+able to run the build.
+
 ## Getting Started
   * Make sure you have a [GitHub][github-join] account.
   * Submit a ticket for your issue in the [DC/OS JIRA][dcos-jira], using the component

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.7
+RUN apt-get update && apt-get install -y \
+	tree


### PR DESCRIPTION
It installs the `tree` dependency. At some point in the future the build may not require `tree` at which point we can remove the Dockerfile and just instruct folks to use `golang:1.7`.

cc @philipnrmn 