### PR TITLE
Close response entity reader.

### DIFF
--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -210,6 +210,7 @@ func (p *Plugin) setEndpoints() error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -246,7 +247,7 @@ func makeMetricsRequest(request *http.Request) (producers.MetricsMessage, error)
 		l.Errorf("Encountered error requesting data, %s", err.Error())
 		return mm, err
 	}
-
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		l.Errorf("Encountered error reading response body, %s", err.Error())


### PR DESCRIPTION
After each request we should be closing response.Body in a defer statement
if we plan on reading the response.