### PR TITLE
Librato Plugin

### DIFF
--- a/plugins/librato/README.md
+++ b/plugins/librato/README.md
@@ -1,0 +1,72 @@
+# Librato Service Plugin for DC/OS
+This plugin supports sending metrics from the DC/OS metrics service on both master and agent hosts to [Librato](https://metrics.librato.com).
+
+## Installation
+
+### Build this plugin (requires a Golang environment)
+1. `git clone git@github.com:dcos/dcos-metrics`
+1. `cd dcos-metrics && make build plugins`
+
+The plugin will be available in the build directory:
+
+```
+$ tree build
+build/
+|-- collector
+|   `-- dcos-metrics-collector-1.1.0-44-ga9f1e73
+|-- plugins
+|   `-- dcos-metrics-librato-plugin@1.1.0-44-ga9f1e73
+`-- statsd-emitter
+    `-- dcos-metrics-statsd-emitter-1.1.0-44-ga9f1e73
+```
+
+### Install the DC/OS Librato metrics plugin
+For each host in your cluster, you'll need to transfer the binary you build for the plugin and then add a systemd unit to manage the service. This unit differs slightly between agent and master hosts.
+
+#### Create a Valid Auth Token for DC/OS
+The DC/OS docs have good info on making this auth token for [OSS](https://dcos.io/docs/1.7/administration/id-and-access-mgt/managing-authentication/) and [enterprise](https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/) DC/OS.
+
+#### Deploy the Metrics Plugin to Every Cluster Host
+1. `scp build/plugins/dcos-metrics-librato-plugin@1.1.0-44-ga9f1e73 my.host:/usr/bin`
+1. `ssh my.master "chmod 0755 /usr/bin/dcos-metrics-librato-plugin@1.1.0-44-ga9f1e73"`
+
+#### Master Systemd Unit
+Add a master systemd unit file: `cat /etc/systemd/system/dcos-metrics-librato-plugin.service`
+
+```
+[Unit]
+Description=DC/OS Librato Metrics Plugin (master)
+
+[Service]
+ExecStart=/usr/bin/dcos-metrics-librato-plugin@1.1.0-44-ga9f1e73 \
+	-dcos-role master \
+	-auth-token <MY_AUTH_TOKEN> \
+	-metrics-port 80 \
+	-librato-email "your librato email" \
+	-librato-token "your librato API token with record permissions" \
+	-librato-metric-prefix "dcos"
+```
+
+#### Agent Systemd Unit
+Add a agent systemd unit file: `cat /etc/systemd/system/dcos-metrics-librato-plugin.service`
+
+```
+[Unit]
+Description=DC/OS Librato Metrics Plugin (agent)
+
+[Service]
+ExecStart=/usr/bin/dcos-metrics-librato-plugin@1.1.0-44-ga9f1e73 \
+	-dcos-role agent \
+	-auth-token <MY_AUTH_TOKEN> \
+	-librato-email "your librato email" \
+	-librato-token "your librato API token with record permissions" \
+	-librato-metric-prefix "dcos"
+```
+
+*Note:* This plugin runs on port :61001 (agent adminrouter) by default, so we don't pass the port as we did in the master version of the service.
+
+#### Enable, Start & Verify
+1. `systemctl enable dcos-metrics-librato-plugin && systemctl start dcos-metrics-librato-plugin`
+1. `journalctl -u dcos-metrics-librato-plugin` -> Make sure everything is OK
+
+## That's it!

--- a/plugins/librato/librato.go
+++ b/plugins/librato/librato.go
@@ -59,12 +59,12 @@ func main() {
 			}
 			post, err := newPostRequest(opts)
 			if err != nil {
-				log.Errorf("Could not build post request: %v", err)
+				log.Errorf("Could not build post request: %s", err)
 				return nil
 			}
 			post.add(metrics)
 			if err := post.send(); err != nil {
-				log.Errorf("Could not post to Librato: %v", err)
+				log.Errorf("Could not post to Librato: %s", err)
 				return nil
 			}
 			return nil

--- a/plugins/librato/librato.go
+++ b/plugins/librato/librato.go
@@ -25,7 +25,7 @@ var (
 	libratoEmailFlagName  = "librato-email"
 	libratoTokenFlagName  = "librato-token"
 	libratoPrefixFlagName = "librato-metric-prefix"
-	libratoUrl            = "https://metrics-api.librato.com"
+	libratoURL            = "https://metrics-api.librato.com"
 	pluginFlags           = []cli.Flag{
 		cli.StringFlag{
 			Name:  libratoEmailFlagName,
@@ -51,7 +51,7 @@ func main() {
 		plugin.ConnectorFunc(func(metrics []producers.MetricsMessage, context *cli.Context) error {
 			log.Infof("Processing %d metrics", len(metrics))
 			opts := &postRequestOpts{
-				libratoUrl:      libratoUrl,
+				libratoURL:      libratoURL,
 				libratoEmail:    context.String(libratoEmailFlagName),
 				libratoToken:    context.String(libratoTokenFlagName),
 				pollingInterval: context.Int64("polling-interval"),

--- a/plugins/librato/librato.go
+++ b/plugins/librato/librato.go
@@ -46,7 +46,7 @@ var (
 func main() {
 	log.Info("Starting Librato DC/OS metrics plugin")
 	libratoPlugin, err := plugin.New(
-		plugin.PluginName("librato"),
+		plugin.Name("librato"),
 		plugin.ExtraFlags(pluginFlags),
 		plugin.ConnectorFunc(func(metrics []producers.MetricsMessage, context *cli.Context) error {
 			log.Infof("Processing %d metrics", len(metrics))

--- a/plugins/librato/librato.go
+++ b/plugins/librato/librato.go
@@ -22,10 +22,11 @@ import (
 )
 
 var (
-	libratoEmailFlagName = "librato-email"
-	libratoTokenFlagName = "librato-token"
-	libratoUrl           = "https://metrics-api.librato.com"
-	pluginFlags          = []cli.Flag{
+	libratoEmailFlagName  = "librato-email"
+	libratoTokenFlagName  = "librato-token"
+	libratoPrefixFlagName = "librato-metric-prefix"
+	libratoUrl            = "https://metrics-api.librato.com"
+	pluginFlags           = []cli.Flag{
 		cli.StringFlag{
 			Name:  libratoEmailFlagName,
 			Usage: "Librato user email address",
@@ -33,6 +34,11 @@ var (
 		cli.StringFlag{
 			Name:  libratoTokenFlagName,
 			Usage: "Librato user API token (must have record access)",
+		},
+		cli.StringFlag{
+			Name:  libratoPrefixFlagName,
+			Usage: "Metric name prefix applied to all metrics sent to Librato",
+			Value: "dcos",
 		},
 	}
 )
@@ -49,6 +55,7 @@ func main() {
 				libratoEmail:    context.String(libratoEmailFlagName),
 				libratoToken:    context.String(libratoTokenFlagName),
 				pollingInterval: context.Int64("polling-interval"),
+				metricPrefix:    context.String(libratoPrefixFlagName),
 			}
 			post, err := newPostRequest(opts)
 			if err != nil {

--- a/plugins/librato/librato.go
+++ b/plugins/librato/librato.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/dcos/dcos-metrics/plugins"
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/urfave/cli"
+)
+
+var (
+	libratoEmailFlagName = "librato-email"
+	libratoTokenFlagName = "librato-token"
+	libratoUrl           = "https://metrics-api.librato.com"
+	pluginFlags          = []cli.Flag{
+		cli.StringFlag{
+			Name:  libratoEmailFlagName,
+			Usage: "Librato user email address",
+		},
+		cli.StringFlag{
+			Name:  libratoTokenFlagName,
+			Usage: "Librato user API token (must have record access)",
+		},
+	}
+)
+
+func main() {
+	log.Info("Starting Librato DC/OS metrics plugin")
+	libratoPlugin, err := plugin.New(
+		plugin.PluginName("librato"),
+		plugin.ExtraFlags(pluginFlags),
+		plugin.ConnectorFunc(func(metrics []producers.MetricsMessage, context *cli.Context) error {
+			log.Infof("Processing %d metrics", len(metrics))
+			opts := &postRequestOpts{
+				libratoUrl:      libratoUrl,
+				libratoEmail:    context.String(libratoEmailFlagName),
+				libratoToken:    context.String(libratoTokenFlagName),
+				pollingInterval: context.Int64("polling-interval"),
+			}
+			post, err := newPostRequest(opts)
+			if err != nil {
+				log.Errorf("Could not build post request: %v", err)
+				return nil
+			}
+			post.add(metrics)
+			if err := post.send(); err != nil {
+				log.Errorf("Could not post to Librato: %v", err)
+				return nil
+			}
+			return nil
+		}))
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Fatal(libratoPlugin.StartPlugin())
+}

--- a/plugins/librato/librato_response.go
+++ b/plugins/librato/librato_response.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// librato responses with code 202 will be unmarshaled into a libratoResponse
+type libratoResponse struct {
+	Measurements libratoMeasurements `json:"measurements"`
+}
+
+type libratoMeasurements struct {
+	Summary libratoSummary `json:"summary"`
+	Errors  []string       `json:"errors"`
+}
+
+type libratoSummary struct {
+	Total    int64 `json:"total"`
+	Accepted int64 `json:"accepted"`
+	Failed   int64 `json:"failed"`
+}
+
+// for testing
+func (l *libratoResponse) addError(err string) {
+	l.Measurements.Summary.Failed += 1
+	l.Measurements.Summary.Total += 1
+	l.Measurements.Errors = append(l.Measurements.Errors, err)
+}
+
+// for testing
+func (l *libratoResponse) addAccepted() {
+	l.Measurements.Summary.Accepted += 1
+	l.Measurements.Summary.Total += 1
+}

--- a/plugins/librato/librato_response.go
+++ b/plugins/librato/librato_response.go
@@ -32,13 +32,13 @@ type libratoSummary struct {
 
 // for testing
 func (l *libratoResponse) addError(err string) {
-	l.Measurements.Summary.Failed += 1
-	l.Measurements.Summary.Total += 1
+	l.Measurements.Summary.Failed++
+	l.Measurements.Summary.Total++
 	l.Measurements.Errors = append(l.Measurements.Errors, err)
 }
 
 // for testing
 func (l *libratoResponse) addAccepted() {
-	l.Measurements.Summary.Accepted += 1
-	l.Measurements.Summary.Total += 1
+	l.Measurements.Summary.Accepted++
+	l.Measurements.Summary.Total++
 }

--- a/plugins/librato/measurement.go
+++ b/plugins/librato/measurement.go
@@ -1,0 +1,104 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+)
+
+// measurement represents each point in a time series
+type measurement struct {
+	Name  string            `json:"name"`
+	Value float64           `json:"value"`
+	Tags  map[string]string `json:"tags"`
+	Time  int64             `json:"time"`
+}
+
+func newMeasurement() *measurement {
+	return &measurement{
+		Tags: make(map[string]string),
+	}
+}
+
+func (m *measurement) floorTime(interval int64) {
+	m.Time = m.Time / interval * interval
+}
+
+func (m *measurement) String() string {
+	return m.Name
+}
+
+func (m *measurement) setValue(value interface{}) error {
+	val, err := m.toFloat64(value)
+	if err != nil {
+		return fmt.Errorf("Could not set value: %v", err)
+	}
+	m.Value = val
+	return nil
+}
+
+func (m *measurement) addTag(name string, value string) error {
+	matched, err := regexp.MatchString(`^[-.:_\w]+\z{1,64}$`, name)
+	if err != nil {
+		return fmt.Errorf("Error occurred matching tag name: %v", err)
+	}
+	if !matched {
+		return fmt.Errorf("Tag name '%s' is not valid", name)
+	}
+	matched, err = regexp.MatchString(`^[-.:_\\/\w ]{1,255}$`, value)
+	if err != nil {
+		return fmt.Errorf("Error occurred matching tag value: %v", err)
+	}
+	if !matched {
+		return fmt.Errorf("Tag value '%s' is not valid", value)
+	}
+	m.Tags[name] = value
+	return nil
+}
+
+func (m *measurement) toFloat64(value interface{}) (float64, error) {
+	switch value := value.(type) {
+	case float64:
+		return value, nil
+	case float32:
+		return float64(value), nil
+	case int64:
+		return float64(value), nil
+	case int32:
+		return float64(value), nil
+	case int:
+		return float64(value), nil
+	case string:
+		return strconv.ParseFloat(value, 64)
+	}
+	return math.NaN(), fmt.Errorf("Could not convert %+v (%T) to float64", value, value)
+}
+
+func (m *measurement) validate() error {
+	if len(m.Tags) == 0 {
+		return errors.New("Must have at least one tag")
+	}
+	if len(m.Name) == 0 {
+		return errors.New("Must have a non-empty name")
+	}
+	if m.Time <= 0 {
+		return errors.New("Time must be >= 0")
+	}
+	return nil
+}

--- a/plugins/librato/measurement.go
+++ b/plugins/librato/measurement.go
@@ -52,7 +52,7 @@ func (m *measurement) String() string {
 func (m *measurement) setValue(value interface{}) error {
 	val, err := plugin.DatapointValueToFloat64(value)
 	if err != nil {
-		return fmt.Errorf("Could not set value: %v", err)
+		return fmt.Errorf("Could not set value: %s", err)
 	}
 	m.Value = val
 	return nil
@@ -61,14 +61,14 @@ func (m *measurement) setValue(value interface{}) error {
 func (m *measurement) addTag(name string, value string) error {
 	matched, err := regexp.MatchString(`^[-.:_\w]+\z{1,64}$`, name)
 	if err != nil {
-		return fmt.Errorf("Error occurred matching tag name: %v", err)
+		return fmt.Errorf("Error occurred matching tag name: %s", err)
 	}
 	if !matched {
 		return fmt.Errorf("Tag name '%s' is not valid", name)
 	}
 	matched, err = regexp.MatchString(`^[-.:_\\/\w ]{1,255}$`, value)
 	if err != nil {
-		return fmt.Errorf("Error occurred matching tag value: %v", err)
+		return fmt.Errorf("Error occurred matching tag value: %s", err)
 	}
 	if !matched {
 		return fmt.Errorf("Tag value '%s' is not valid", value)

--- a/plugins/librato/measurement.go
+++ b/plugins/librato/measurement.go
@@ -38,6 +38,10 @@ func newMeasurement() *measurement {
 }
 
 func (m *measurement) floorTime(interval int64) {
+	if interval <= 0 {
+		log.Errorf("Attempted to floor measurement time with interval %d", interval)
+		return
+	}
 	m.Time = m.Time / interval * interval
 }
 

--- a/plugins/librato/measurement.go
+++ b/plugins/librato/measurement.go
@@ -17,9 +17,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"math"
 	"regexp"
-	"strconv"
+
+	"github.com/dcos/dcos-metrics/plugins"
 )
 
 // measurement represents each point in a time series
@@ -45,7 +45,7 @@ func (m *measurement) String() string {
 }
 
 func (m *measurement) setValue(value interface{}) error {
-	val, err := m.toFloat64(value)
+	val, err := plugin.DatapointValueToFloat64(value)
 	if err != nil {
 		return fmt.Errorf("Could not set value: %v", err)
 	}
@@ -70,24 +70,6 @@ func (m *measurement) addTag(name string, value string) error {
 	}
 	m.Tags[name] = value
 	return nil
-}
-
-func (m *measurement) toFloat64(value interface{}) (float64, error) {
-	switch value := value.(type) {
-	case float64:
-		return value, nil
-	case float32:
-		return float64(value), nil
-	case int64:
-		return float64(value), nil
-	case int32:
-		return float64(value), nil
-	case int:
-		return float64(value), nil
-	case string:
-		return strconv.ParseFloat(value, 64)
-	}
-	return math.NaN(), fmt.Errorf("Could not convert %+v (%T) to float64", value, value)
 }
 
 func (m *measurement) validate() error {

--- a/plugins/librato/measurement.go
+++ b/plugins/librato/measurement.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"regexp"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/dcos/dcos-metrics/plugins"
 )
 
@@ -67,6 +68,9 @@ func (m *measurement) addTag(name string, value string) error {
 	}
 	if !matched {
 		return fmt.Errorf("Tag value '%s' is not valid", value)
+	}
+	if found, ok := m.Tags[name]; ok && found != value {
+		log.Warnf("Existing tag '%s'='%s' being overwritten with '%s", name, found, value)
 	}
 	m.Tags[name] = value
 	return nil

--- a/plugins/librato/measurement_test.go
+++ b/plugins/librato/measurement_test.go
@@ -62,7 +62,7 @@ func TestMeasurementTags(t *testing.T) {
 			t.Fatalf("Test case %+v should have failed", tc)
 		}
 		if !tc.expectError && err != nil {
-			t.Fatalf("Test case %+v should not have failed but did: %v", tc, err)
+			t.Fatalf("Test case %+v should not have failed but did: %s", tc, err)
 		}
 	}
 }
@@ -94,7 +94,7 @@ func TestMeasurementSetValue(t *testing.T) {
 			t.Fatalf("Test case %+v should have failed", tc)
 		}
 		if !tc.expectError && err != nil {
-			t.Fatalf("Test case %+v should not have failed but did: %v", tc, err)
+			t.Fatalf("Test case %+v should not have failed but did: %s", tc, err)
 		}
 	}
 }

--- a/plugins/librato/measurement_test.go
+++ b/plugins/librato/measurement_test.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMeasurementTags(t *testing.T) {
+	type testCase struct {
+		name        string
+		value       string
+		expectError bool
+	}
+	testCases := []testCase{
+		// passing cases
+		{"foo", "bar", false},
+		{"label:foo", "bar", false},
+
+		// failing cases
+		{"", "bar", true},
+		{"command", "()", true},
+	}
+	for _, tc := range testCases {
+		measurement := newMeasurement()
+		err := measurement.addTag(tc.name, tc.value)
+		if tc.expectError && err == nil {
+			t.Fatalf("Test case %+v should have failed", tc)
+		}
+		if !tc.expectError && err != nil {
+			t.Fatalf("Test case %+v should not have failed but did: %v", tc, err)
+		}
+	}
+}
+
+func TestMeasurementSetValue(t *testing.T) {
+	type testCase struct {
+		value       interface{}
+		expectError bool
+	}
+	testCases := []testCase{
+		// passing cases
+		{5, false},
+		{5.0, false},
+		{int(5), false},
+		{int32(5), false},
+		{int64(5), false},
+		{float32(5), false},
+		{float64(5), false},
+		{"3.1415", false},
+
+		// failing cases
+		{"not a number", true},
+		{new(http.Client), true},
+	}
+	for _, tc := range testCases {
+		measurement := newMeasurement()
+		err := measurement.setValue(tc.value)
+		if tc.expectError && err == nil {
+			t.Fatalf("Test case %+v should have failed", tc)
+		}
+		if !tc.expectError && err != nil {
+			t.Fatalf("Test case %+v should not have failed but did: %v", tc, err)
+		}
+	}
+}

--- a/plugins/librato/measurement_test.go
+++ b/plugins/librato/measurement_test.go
@@ -19,6 +19,27 @@ import (
 	"testing"
 )
 
+func TestFloorTime(t *testing.T) {
+	type testCase struct {
+		time     int64
+		interval int64
+		expected int64
+	}
+	testCases := []testCase{
+		{time: 1024, interval: 1000, expected: 1000},
+		{time: 1024, interval: 0, expected: 1024},
+		{time: 1024, interval: -52, expected: 1024},
+	}
+	for _, tc := range testCases {
+		measurement := newMeasurement()
+		measurement.Time = tc.time
+		measurement.floorTime(tc.interval)
+		if measurement.Time != tc.expected {
+			t.Fatalf("Test case %+v got unexpected value %d", tc, tc.expected)
+		}
+	}
+}
+
 func TestMeasurementTags(t *testing.T) {
 	type testCase struct {
 		name        string

--- a/plugins/librato/post_request.go
+++ b/plugins/librato/post_request.go
@@ -1,0 +1,208 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/dcos/dcos-metrics/producers"
+)
+
+// retained to take advantage of connection re-use
+var httpClient http.Client
+
+func init() {
+	httpClient.Timeout = 5 * time.Second
+}
+
+// postRequest is the main payload to librato
+type postRequest struct {
+	Measurements []*measurement `json:"measurements"`
+	opts         *postRequestOpts
+}
+
+// postRequestOpts are the configurable options for postRequest
+type postRequestOpts struct {
+	libratoUrl      string
+	libratoEmail    string
+	libratoToken    string
+	pollingInterval int64
+}
+
+func newPostRequest(opts *postRequestOpts) (*postRequest, error) {
+	isBlank := func(str string) bool {
+		return len(strings.TrimSpace(str)) == 0
+	}
+	if isBlank(opts.libratoUrl) {
+		return nil, errors.New("Librato url must be specified")
+	}
+	if isBlank(opts.libratoEmail) {
+		return nil, errors.New("Librato email address must be specified")
+	}
+	if isBlank(opts.libratoToken) {
+		return nil, errors.New("Librato account token must be specified")
+	}
+	if opts.pollingInterval <= 0 {
+		return nil, errors.New("Polling interval must be >= 0")
+	}
+	pr := &postRequest{
+		opts: opts,
+	}
+	return pr, nil
+}
+
+func (p *postRequest) add(messages []producers.MetricsMessage) {
+	oldDatapoints := 0
+	for _, message := range messages {
+		dimensions := message.Dimensions
+		for _, datapoint := range message.Datapoints {
+			measurement := newMeasurement()
+			measurement.Name = datapoint.Name
+			timestamp, err := p.parseTimestamp(datapoint.Timestamp)
+			if err != nil {
+				log.Errorf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err)
+				continue
+			}
+			if timestamp.Before(time.Now().Add(-10 * time.Minute)) {
+				log.Debugf("Timestamp '%s' for '%s' is too old", datapoint.Timestamp, datapoint.Name)
+				oldDatapoints++
+				continue
+			}
+			measurement.Time = timestamp.Unix()
+			measurement.floorTime(p.opts.pollingInterval)
+			for k, v := range datapoint.Tags {
+				p.setTag(measurement, k, v)
+			}
+			p.setTag(measurement, "mesosId", dimensions.MesosID)
+			p.setTag(measurement, "clusterId", dimensions.ClusterID)
+			p.setTag(measurement, "containerId", dimensions.ContainerID)
+			p.setTag(measurement, "executorId", dimensions.ExecutorID)
+			p.setTag(measurement, "frameworkName", dimensions.FrameworkName)
+			p.setTag(measurement, "frameworkId", dimensions.FrameworkID)
+			p.setTag(measurement, "frameworkRole", dimensions.FrameworkRole)
+			p.setTag(measurement, "frameworkPrincipal", dimensions.FrameworkPrincipal)
+			p.setTag(measurement, "hostname", dimensions.Hostname)
+			for k, v := range dimensions.Labels {
+				p.setTag(measurement, fmt.Sprintf("label:%s", k), v)
+			}
+			if err := measurement.setValue(datapoint.Value); err != nil {
+				log.Errorf("Skipping datapoint '%s' due to an invalid value: %v", measurement, err)
+				continue
+			}
+			if err := measurement.validate(); err != nil {
+				log.Errorf("Skipping datapoint '%s' due to a validation error: %v", measurement, err)
+				continue
+			}
+			p.Measurements = append(p.Measurements, measurement)
+		}
+	}
+	if oldDatapoints > 0 {
+		log.Warnf("Rejected %d datapoints because they were too old", oldDatapoints)
+	}
+}
+
+func (p *postRequest) parseTimestamp(timestamp string) (*time.Time, error) {
+	if timestamp == "" {
+		return nil, errors.New("Received an empty timestamp")
+	}
+	parsed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
+func (p *postRequest) setTag(m *measurement, name string, value string) {
+	if len(value) == 0 {
+		// don't bother if a tag value was not specified
+		return
+	}
+	if err := m.addTag(name, value); err != nil {
+		// some tags cannot be used, this will get noisy if on the warn level
+		log.Debugf("Invalid tag '%s'='%s' for measurement '%s': %v", name, value, m, err)
+	}
+}
+
+func (p *postRequest) floorTime(value int64) int64 {
+	if value <= 0 {
+		value = time.Now().Unix()
+	}
+	// floor the timestamp to the polling interval to align datapoints
+	return value / p.opts.pollingInterval * p.opts.pollingInterval
+}
+
+func (p *postRequest) send() error {
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("Could not marshal request: %v", err)
+	}
+	url := p.opts.libratoUrl + "/v1/measurements"
+	req, err := http.NewRequest("POST", url, bytes.NewReader(encoded))
+	if err != nil {
+		return fmt.Errorf("Could not build request: %v", err)
+	}
+	authHeader, err := p.authHeader()
+	if err != nil {
+		return fmt.Errorf("Could not create authentication header: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return p.checkResponse(resp)
+}
+
+func (p *postRequest) checkResponse(resp *http.Response) error {
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Got response code %d but could not read body: %v", resp.StatusCode, err)
+	}
+	if resp.StatusCode == http.StatusAccepted {
+		var libratoResponse libratoResponse
+		if err := json.Unmarshal(respBody, &libratoResponse); err != nil {
+			return fmt.Errorf("Got response code %d but could not decode response body: %v", resp.StatusCode, err)
+		}
+		if libratoResponse.Measurements.Summary.Failed == 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("Librato responded with code: %d and body: %s", resp.StatusCode, string(respBody))
+}
+
+func (p *postRequest) authHeader() (string, error) {
+	libratoEmail := p.opts.libratoEmail
+	libratoToken := p.opts.libratoToken
+	if len(strings.TrimSpace(libratoEmail)) == 0 {
+		return "", errors.New("The " + libratoEmailFlagName + " flag must be specified.")
+	}
+	if len(strings.TrimSpace(libratoToken)) == 0 {
+		return "", errors.New("The " + libratoTokenFlagName + " flag must be specified.")
+	}
+	userPass := fmt.Sprintf("%s:%s", libratoEmail, libratoToken)
+	base64Encoded := base64.StdEncoding.EncodeToString([]byte(userPass))
+	return fmt.Sprintf("Basic %s", base64Encoded), nil
+}

--- a/plugins/librato/post_request.go
+++ b/plugins/librato/post_request.go
@@ -45,7 +45,7 @@ type postRequest struct {
 
 // postRequestOpts are the configurable options for postRequest
 type postRequestOpts struct {
-	libratoUrl      string
+	libratoURL      string
 	libratoEmail    string
 	libratoToken    string
 	metricPrefix    string
@@ -56,7 +56,7 @@ func newPostRequest(opts *postRequestOpts) (*postRequest, error) {
 	isBlank := func(str string) bool {
 		return len(strings.TrimSpace(str)) == 0
 	}
-	if isBlank(opts.libratoUrl) {
+	if isBlank(opts.libratoURL) {
 		return nil, errors.New("Librato url must be specified")
 	}
 	if isBlank(opts.libratoEmail) {
@@ -155,7 +155,7 @@ func (p *postRequest) send() error {
 	if err != nil {
 		return fmt.Errorf("Could not marshal request: %v", err)
 	}
-	url := p.opts.libratoUrl + "/v1/measurements"
+	url := p.opts.libratoURL + "/v1/measurements"
 	req, err := http.NewRequest("POST", url, bytes.NewReader(encoded))
 	if err != nil {
 		return fmt.Errorf("Could not build request: %v", err)

--- a/plugins/librato/post_request.go
+++ b/plugins/librato/post_request.go
@@ -96,14 +96,14 @@ func (p *postRequest) add(messages []producers.MetricsMessage) {
 			for k, v := range datapoint.Tags {
 				p.setTag(measurement, k, v)
 			}
-			p.setTag(measurement, "mesosId", dimensions.MesosID)
-			p.setTag(measurement, "clusterId", dimensions.ClusterID)
-			p.setTag(measurement, "containerId", dimensions.ContainerID)
-			p.setTag(measurement, "executorId", dimensions.ExecutorID)
-			p.setTag(measurement, "frameworkName", dimensions.FrameworkName)
-			p.setTag(measurement, "frameworkId", dimensions.FrameworkID)
-			p.setTag(measurement, "frameworkRole", dimensions.FrameworkRole)
-			p.setTag(measurement, "frameworkPrincipal", dimensions.FrameworkPrincipal)
+			p.setTag(measurement, "mesos_id", dimensions.MesosID)
+			p.setTag(measurement, "cluster_id", dimensions.ClusterID)
+			p.setTag(measurement, "container_id", dimensions.ContainerID)
+			p.setTag(measurement, "executor_id", dimensions.ExecutorID)
+			p.setTag(measurement, "framework_name", dimensions.FrameworkName)
+			p.setTag(measurement, "framework_id", dimensions.FrameworkID)
+			p.setTag(measurement, "framework_role", dimensions.FrameworkRole)
+			p.setTag(measurement, "framework_principal", dimensions.FrameworkPrincipal)
 			p.setTag(measurement, "hostname", dimensions.Hostname)
 			for k, v := range dimensions.Labels {
 				p.setTag(measurement, fmt.Sprintf("label:%s", k), v)

--- a/plugins/librato/post_request.go
+++ b/plugins/librato/post_request.go
@@ -48,6 +48,7 @@ type postRequestOpts struct {
 	libratoUrl      string
 	libratoEmail    string
 	libratoToken    string
+	metricPrefix    string
 	pollingInterval int64
 }
 
@@ -79,7 +80,7 @@ func (p *postRequest) add(messages []producers.MetricsMessage) {
 		dimensions := message.Dimensions
 		for _, datapoint := range message.Datapoints {
 			measurement := newMeasurement()
-			measurement.Name = datapoint.Name
+			measurement.Name = p.metricName(datapoint.Name)
 			timestamp, err := plugin.ParseDatapointTimestamp(datapoint.Timestamp)
 			if err != nil {
 				log.Errorf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err)
@@ -121,6 +122,13 @@ func (p *postRequest) add(messages []producers.MetricsMessage) {
 	if oldDatapoints > 0 {
 		log.Warnf("Rejected %d datapoints because they were too old", oldDatapoints)
 	}
+}
+
+func (p *postRequest) metricName(name string) string {
+	if p.opts.metricPrefix != "" {
+		return p.opts.metricPrefix + "." + name
+	}
+	return name
 }
 
 func (p *postRequest) setTag(m *measurement, name string, value string) {

--- a/plugins/librato/post_request.go
+++ b/plugins/librato/post_request.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/dcos/dcos-metrics/plugins"
 	"github.com/dcos/dcos-metrics/producers"
 )
 
@@ -79,7 +80,7 @@ func (p *postRequest) add(messages []producers.MetricsMessage) {
 		for _, datapoint := range message.Datapoints {
 			measurement := newMeasurement()
 			measurement.Name = datapoint.Name
-			timestamp, err := p.parseTimestamp(datapoint.Timestamp)
+			timestamp, err := plugin.ParseDatapointTimestamp(datapoint.Timestamp)
 			if err != nil {
 				log.Errorf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err)
 				continue
@@ -120,17 +121,6 @@ func (p *postRequest) add(messages []producers.MetricsMessage) {
 	if oldDatapoints > 0 {
 		log.Warnf("Rejected %d datapoints because they were too old", oldDatapoints)
 	}
-}
-
-func (p *postRequest) parseTimestamp(timestamp string) (*time.Time, error) {
-	if timestamp == "" {
-		return nil, errors.New("Received an empty timestamp")
-	}
-	parsed, err := time.Parse(time.RFC3339, timestamp)
-	if err != nil {
-		return nil, err
-	}
-	return &parsed, nil
 }
 
 func (p *postRequest) setTag(m *measurement, name string, value string) {

--- a/plugins/librato/post_request_test.go
+++ b/plugins/librato/post_request_test.go
@@ -1,0 +1,150 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/dcos/dcos-metrics/producers"
+)
+
+var (
+	datapointTime = time.Now()
+	expectedTime  = time.Unix(datapointTime.Unix()/10*10, 0)
+	testMessages  = []producers.MetricsMessage{
+		{
+			Datapoints: []producers.Datapoint{
+				{
+					Name: "my-metric",
+					Tags: map[string]string{
+						"tag1": "value1",
+					},
+					Value:     42,
+					Timestamp: datapointTime.Format(time.RFC3339),
+				},
+			},
+		},
+	}
+	testLibratoEmail    = "test@example.com"
+	testLibratoToken    = "testToken"
+	testPollingInterval = int64(10)
+)
+
+func TestPostRequest(t *testing.T) {
+	libratoResponse := &libratoResponse{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		// verify the request that the postRequest sent
+		if r.Header.Get("Authorization") != expectedTestAuth() {
+			t.Fatal("Authentication header was wrong")
+		}
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Could not read request body: %v", err)
+		}
+		var postRequest postRequest
+		if err := json.Unmarshal(b, &postRequest); err != nil {
+			t.Fatal(err)
+		}
+		if len(postRequest.Measurements) != 1 {
+			t.Fatalf("Should have been 1 measure but instead there were %d", len(postRequest.Measurements))
+		}
+		measurement := postRequest.Measurements[0]
+		if measurement.Value != 42 {
+			t.Fatalf("Measure should have been 42 but was %f", measurement.Value)
+		}
+		if measurement.Name != "my-metric" {
+			t.Fatalf("Measure name should have been 'my-metric' but was %s", measurement.Name)
+		}
+		// verify that the measure time was floored to the polling interval
+		if measurement.Time != expectedTime.Unix() {
+			t.Fatalf("Measure time should have been 1000 but was %d", measurement.Time)
+		}
+		if !reflect.DeepEqual(measurement.Tags, map[string]string{
+			"tag1": "value1",
+		}) {
+			t.Fatalf("Tags were wrong: %v", measurement.Tags)
+		}
+
+		// send a response to the postRequest
+		b, err = json.Marshal(libratoResponse)
+		if err != nil {
+			http.Error(w, "Could not serialize: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		if _, err := w.Write(b); err != nil {
+			t.Fatalf("Could not write response: %s", err)
+		}
+	}))
+	postRequest, err := newTestPostRequest(server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	postRequest.add(testMessages)
+	if err := postRequest.send(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostRequestFailure(t *testing.T) {
+	libratoResponse := &libratoResponse{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		// fake an erroneous response
+		libratoResponse.addError("test-error")
+		b, err := json.Marshal(libratoResponse)
+		if err != nil {
+			http.Error(w, "Could not serialize: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		if _, err := w.Write(b); err != nil {
+			t.Fatalf("Could not write response: %s", err)
+		}
+	}))
+	postRequest, err := newTestPostRequest(server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	postRequest.add(testMessages)
+	if err := postRequest.send(); err == nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestPostRequest(server *httptest.Server) (*postRequest, error) {
+	return newPostRequest(&postRequestOpts{
+		libratoUrl:      server.URL,
+		libratoEmail:    testLibratoEmail,
+		libratoToken:    testLibratoToken,
+		pollingInterval: testPollingInterval,
+	})
+}
+
+func expectedTestAuth() string {
+	authChunk := fmt.Sprintf("%s:%s", testLibratoEmail, testLibratoToken)
+	encoded := base64.StdEncoding.EncodeToString([]byte(authChunk))
+	return fmt.Sprintf("Basic %s", string(encoded))
+}

--- a/plugins/librato/post_request_test.go
+++ b/plugins/librato/post_request_test.go
@@ -137,7 +137,7 @@ func TestPostRequestFailure(t *testing.T) {
 
 func newTestPostRequest(server *httptest.Server) (*postRequest, error) {
 	return newPostRequest(&postRequestOpts{
-		libratoUrl:      server.URL,
+		libratoURL:      server.URL,
 		libratoEmail:    testLibratoEmail,
 		libratoToken:    testLibratoToken,
 		pollingInterval: testPollingInterval,

--- a/plugins/librato/post_request_test.go
+++ b/plugins/librato/post_request_test.go
@@ -48,6 +48,7 @@ var (
 	testLibratoEmail    = "test@example.com"
 	testLibratoToken    = "testToken"
 	testPollingInterval = int64(10)
+	testMetricPrefix    = "dcos"
 )
 
 func TestPostRequest(t *testing.T) {
@@ -74,7 +75,7 @@ func TestPostRequest(t *testing.T) {
 		if measurement.Value != 42 {
 			t.Fatalf("Measure should have been 42 but was %f", measurement.Value)
 		}
-		if measurement.Name != "my-metric" {
+		if measurement.Name != "dcos.my-metric" {
 			t.Fatalf("Measure name should have been 'my-metric' but was %s", measurement.Name)
 		}
 		// verify that the measure time was floored to the polling interval
@@ -140,6 +141,7 @@ func newTestPostRequest(server *httptest.Server) (*postRequest, error) {
 		libratoEmail:    testLibratoEmail,
 		libratoToken:    testLibratoToken,
 		pollingInterval: testPollingInterval,
+		metricPrefix:    testMetricPrefix,
 	})
 }
 

--- a/plugins/librato/post_request_test.go
+++ b/plugins/librato/post_request_test.go
@@ -62,7 +62,7 @@ func TestPostRequest(t *testing.T) {
 		}
 		b, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			t.Fatalf("Could not read request body: %v", err)
+			t.Fatalf("Could not read request body: %s", err)
 		}
 		var postRequest postRequest
 		if err := json.Unmarshal(b, &postRequest); err != nil {


### PR DESCRIPTION
This changeset introduces a new [Librato](https://metrics.librato.com) plugin.  It adapts to the current plugin framework and converts dcos-metrics metrics into Librato metrics and then sends them to Librato.
