### PR TITLE
Syncs the YAML to docsite YAML, which was adjusted for optimal rendering

### DIFF
--- a/docs/HTTP_API.yml
+++ b/docs/HTTP_API.yml
@@ -1,30 +1,16 @@
----
 swagger: "2.0"
-
-############################################################################
-# Info                                                                     #
-############################################################################
 info:
-  version: "0"
-  title: "DC/OS Metrics Service HTTP API"
-  description: >
-    The first version of the DC/OS Metrics Service HTTP API.
+  version: 0.0.0
+  title: 'DC/OS Metrics API'
 
-    Note that the endpoints in this spec are all *service-specific*. dcos-metrics
-    is designed to be put behind Admin Router, which provides security for these
-    endpoints. Therefore, on a DC/OS cluster, the final URL to query will resemble:
-
-        http://<host>/system/v1/metrics/v0/<endpoint>
-
-    For more information, please consult the project documentation located at
-    <https://github.com/dcos/dcos-metrics>.
-basePath: "/v0"
-produces:
-  - "application/json"
-
-############################################################################
-# Parameters                                                               #
-############################################################################
+basePath: '/metrics/v0/'
+tags:
+  - name: ping
+    description: proxy health check
+  - name: node
+    description: host metrics
+  - name: containers
+    description: container metrics
 parameters:
   container-id:
     name: id
@@ -39,13 +25,11 @@ parameters:
     required: true
     type: string
 
-
-############################################################################
-# Paths                                                                    #
-############################################################################
 paths:
   "/ping":
     get:
+      tags:
+        - ping
       description: "Basic health check for load balancers and reverse proxies."
       responses:
         200:
@@ -55,6 +39,8 @@ paths:
 
   "/node":
     get:
+      tags:
+        - node
       description: "Node metrics (CPU, memory, local filesystems, networks, etc)."
       responses:
         200:
@@ -66,6 +52,8 @@ paths:
 
   "/containers":
     get:
+      tags:
+        - containers
       summary: "An array of container IDs running on the node."
       responses:
         200:
@@ -79,6 +67,8 @@ paths:
 
   "/containers/{id}":
     get:
+      tags:
+        - containers
       description: "Resource allocation and usage for the given container ID."
       parameters:
         - $ref: "#/parameters/container-id"
@@ -93,6 +83,8 @@ paths:
 
   "/containers/{id}/app":
     get:
+      tags:
+        - containers
       description: >
         Application-level metrics from the container (shipped in StatsD format using the listener available at `STATSD_UDP_HOST` and `STATSD_UDP_PORT`)"
       parameters:
@@ -107,6 +99,8 @@ paths:
 
   "/containers/{id}/app/{metric-id}":
     get:
+      tags:
+        - containers
       description: >
         Similar to `/v0/containers/{id}/app` but only contains datapoints for a single metric ID.
       parameters:

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -11,7 +11,7 @@ To develop a new plugin in preparation for a pull request to this project:
 1. Make a go file named after your package `touch plugins/cool/cool.go`
 
 #### Get a new plugin.Plugin{}
-1. Create flags: `myFalgs := []cli.Flag{}`
+1. Create flags: `myFlags := []cli.Flag{}`
 1. `myPlugin := plugin.New(myFlags)` -> `plugin.Plugin{}`
 1. Use `myPlugin.App.Action` and pass it a [cli.ActionFunc()](https://github.com/urfave/cli/blob/master/app.go#L66) which has all the `main()` logic your plugin needs.
 1. Call `myPlugin.Metrics()` which returns a slice of `producers.MetricsMessage{}` from the metrics HTTP API.

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -210,6 +210,7 @@ func (p *Plugin) setEndpoints() error {
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()
 
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -246,7 +247,7 @@ func makeMetricsRequest(request *http.Request) (producers.MetricsMessage, error)
 		l.Errorf("Encountered error requesting data, %s", err.Error())
 		return mm, err
 	}
-
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		l.Errorf("Encountered error reading response body, %s", err.Error())


### PR DESCRIPTION
@malnick @darkonie @philipnrmn This PR syncs the dcos-metrics YAML with the docsite YAML. I had to adjust that YAML for better rendering by adding tags. In addition, the docsite renderer displayed a red error with the previous YAML. The introductory content in this YAML is included elsewhere on the site so not needed within the YAML itself. Let me know if this looks OK to you, it will make things easier if we can keep the sources in sync. Thanks!