### PR TITLE
Add standalone datadog plugin

### DIFF
--- a/plugins/datadog-standalone/README.md
+++ b/plugins/datadog-standalone/README.md
@@ -7,22 +7,19 @@ those who do not wish to make use of the Datadog Agent.
 
 ### Build this plugin (requires a Golang environment)
 1. `git clone git@github.com:dcos/dcos-metrics`
-1. `cd dcos-metrics && make`
+1. `cd dcos-metrics && make test && make plugins`
 
-As detailed in the Datadog plugin docs, the resulting binary (dcos-metrics-datadog-standalone-plugin) can then be
-installed on each node in the cluster and run.
+As detailed in the Datadog plugin docs, the resulting binary (dcos-metrics-datadog-standalone-plugin), which will be
+built to the `build/plugins` directory wth the dcos-metrics version appended to its filename, can then be installed on
+each node in the cluster.
 
 This plugin takes a `datadog-key` flag in addition to the normal plugin args; a sample call looks like this:
 
 ```bash
-./dcos-metrics-datadog-standalone-plugin
-  --dcos-role
-  agent
-  --metrics-host
-  localhost
-  --metrics-port
-  9000
-  --auth-token
-  aaZaaZaaZaZZZaZ1ZaZaZaaaZZZ1ZaZaZ1ZaaZZaZaZ1aZZ1ZaaZZZZ1...
-  --datadog-key
-  11a1aaaa1aa11a111aaa1aa111a11111
+./dcos-metrics-datadog-standalone-plugin \
+  --dcos-role    agent \
+  --metrics-host localhost \
+  --metrics-port 9000 \
+  --auth-token   aaZaaZaaZaZZZaZ1ZaZaZaaaZZZ1ZaZaZ1ZaaZZaZaZ1aZZ1ZaaZZZZ1... \
+  --datadog-key  11a1aaaa1aa11a111aaa1aa111a11111
+```

--- a/plugins/datadog-standalone/README.md
+++ b/plugins/datadog-standalone/README.md
@@ -1,7 +1,7 @@
 # Standalone Datadog Metrics Service Plugin for DC/OS
 
-This plugin is an alternative to the [regular Datadog plugin](https://github.com/dcos/dcos-metrics/plugins/datadog) for
-those who do not wish to make use of the Datadog Agent.
+This plugin is an alternative to the [regular Datadog plugin](https://github.com/dcos/dcos-metrics/tree/master/plugins/datadog)
+for those who do not wish to make use of the Datadog Agent.
 
 ## Installation
 

--- a/plugins/datadog-standalone/README.md
+++ b/plugins/datadog-standalone/README.md
@@ -1,0 +1,28 @@
+# Standalone Datadog Metrics Service Plugin for DC/OS
+
+This plugin is an alternative to the [regular Datadog plugin](https://github.com/dcos/dcos-metrics/plugins/datadog) for
+those who do not wish to make use of the Datadog Agent.
+
+## Installation
+
+### Build this plugin (requires a Golang environment)
+1. `git clone git@github.com:dcos/dcos-metrics`
+1. `cd dcos-metrics && make`
+
+As detailed in the Datadog plugin docs, the resulting binary (dcos-metrics-datadog-standalone-plugin) can then be
+installed on each node in the cluster and run.
+
+This plugin takes a `datadog-key` flag in addition to the normal plugin args; a sample call looks like this:
+
+```bash
+./dcos-metrics-datadog-standalone-plugin
+  --dcos-role
+  agent
+  --metrics-host
+  localhost
+  --metrics-port
+  9000
+  --auth-token
+  aaZaaZaaZaZZZaZ1ZaZaZaaaZZZ1ZaZaZ1ZaaZZaZaZ1aZZ1ZaaZZZZ1...
+  --datadog-key
+  11a1aaaa1aa11a111aaa1aa111a11111

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -1,0 +1,218 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	plugin "github.com/dcos/dcos-metrics/plugins"
+	"github.com/dcos/dcos-metrics/producers"
+	"github.com/urfave/cli"
+)
+
+var (
+	pluginFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "datadog-key",
+			Usage: "DataDog API Key",
+		},
+	}
+	datadogConnector = func(metrics []producers.MetricsMessage, c *cli.Context) error {
+		if len(metrics) == 0 {
+			log.Error("No messages received from metrics service")
+		} else {
+			log.Info("Transmitting metrics to DataDog")
+			datadogURL := fmt.Sprintf("https://app.datadoghq.com/api/v1/series?api_key=%s", c.String("datadog-key"))
+
+			s := messagesToSeries(metrics)
+			b := new(bytes.Buffer)
+			json.NewEncoder(b).Encode(s)
+			res, err := http.Post(datadogURL, "application/json; charset=utf-8", b)
+			if err != nil {
+				log.Error(err)
+				return nil
+			}
+			defer res.Body.Close()
+			body, err := ioutil.ReadAll(res.Body)
+			if err != nil {
+				log.Fatal(err)
+				return nil
+			}
+			result := DDResult{}
+			err = json.Unmarshal(body, &result)
+			if err != nil {
+				log.Error(err)
+				return nil
+			}
+			if len(result.Errors) > 0 {
+				log.Error("Encountered errors:")
+				for _, err := range result.Errors {
+					log.Error(err)
+				}
+			}
+			if len(result.Warnings) > 0 {
+				log.Warn("Encountered warnings:")
+				for _, wrn := range result.Warnings {
+					log.Warn(wrn)
+				}
+			}
+			if result.Status == "ok" {
+				log.Info("Successfully transmitted metrics")
+			}
+		}
+
+		return nil
+	}
+)
+
+// DataPoint is a tuple of [UNIX timestamp, value]. This has to use floats
+// because the value could be non-integer.
+type DDDataPoint [2]float64
+
+// Metric represents a collection of data points that we might send or receive
+// on one single metric line.
+type DDMetric struct {
+	Metric string        `json:"metric,omitempty"`
+	Points []DDDataPoint `json:"points,omitempty"`
+	Type   *string       `json:"type,omitempty"`
+	Host   *string       `json:"host,omitempty"`
+	Tags   []string      `json:"tags,omitempty"`
+	Unit   string        `json:"unit,omitempty"`
+}
+
+// Series represents a collection of data points we get when we query for timeseries data
+type DDSeries struct {
+	Series []DDMetric `json:"series"`
+}
+
+// A successful metrics API result
+type DDResult struct {
+	Status   string   `json:"status,omitempty"`
+	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+func main() {
+	log.Info("Starting Standalone DataDog DC/OS metrics plugin")
+	datadogPlugin, err := plugin.New(
+		plugin.PluginName("standalone-datadog"),
+		plugin.ExtraFlags(pluginFlags),
+		plugin.ConnectorFunc(datadogConnector))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Fatal(datadogPlugin.StartPlugin())
+}
+
+func messagesToSeries(messages []producers.MetricsMessage) *DDSeries {
+
+	series := new(DDSeries)
+
+	for _, message := range messages {
+		dimensions := &message.Dimensions
+		host := &dimensions.Hostname
+		messageTags := []string{}
+		addMessageTag := func(key, value string) {
+			if len(value) > 0 {
+				messageTags = append(messageTags, fmt.Sprintf("%s:%s", key, value))
+			}
+		}
+
+		for name, value := range dimensions.Labels {
+			addMessageTag(name, value)
+		}
+		addMessageTag("mesosId", dimensions.MesosID)
+		addMessageTag("clusterId", dimensions.ClusterID)
+		addMessageTag("containerId", dimensions.ContainerID)
+		addMessageTag("executorId", dimensions.ExecutorID)
+		addMessageTag("frameworkName", dimensions.FrameworkName)
+		addMessageTag("frameworkId", dimensions.FrameworkID)
+		addMessageTag("frameworkRole", dimensions.FrameworkRole)
+		addMessageTag("frameworkPrincipal", dimensions.FrameworkPrincipal)
+		addMessageTag("hostname", dimensions.Hostname)
+
+		for _, datapoint := range message.Datapoints {
+			t, err := parseTimestamp(datapoint.Timestamp)
+			if err != nil {
+				log.Errorf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err)
+				continue
+			}
+			v, err := toFloat64(datapoint.Value)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+
+			datapointTags := []string{}
+			addDatapointTag := func(key, value string) {
+				datapointTags = append(datapointTags, fmt.Sprintf("%s:%s", key, value))
+			}
+			for name, value := range datapoint.Tags {
+				addDatapointTag(name, value)
+			}
+
+			metric := DDMetric{
+				Metric: datapoint.Name,
+				Points: []DDDataPoint{{float64(t.Unix()), v}},
+				Tags:   append(messageTags, datapointTags...),
+				Unit:   datapoint.Unit,
+				Host:   host,
+			}
+			series.Series = append(series.Series, metric)
+		}
+	}
+
+	return series
+}
+
+func toFloat64(value interface{}) (float64, error) {
+	switch value := value.(type) {
+	case float64:
+		return value, nil
+	case float32:
+		return float64(value), nil
+	case int64:
+		return float64(value), nil
+	case int32:
+		return float64(value), nil
+	case int:
+		return float64(value), nil
+	case string:
+		return strconv.ParseFloat(value, 64)
+	}
+	return math.NaN(), fmt.Errorf("Could not convert %+v (%T) to float64", value, value)
+}
+
+func parseTimestamp(timestamp string) (*time.Time, error) {
+	if timestamp == "" {
+		return nil, errors.New("Received an empty timestamp")
+	}
+	parsed, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -20,9 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net/http"
-	"strconv"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -160,7 +158,7 @@ func messagesToSeries(messages []producers.MetricsMessage) *DDSeries {
 				log.Errorf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err)
 				continue
 			}
-			v, err := toFloat64(datapoint.Value)
+			v, err := plugin.DatapointValueToFloat64(datapoint.Value)
 			if err != nil {
 				log.Error(err)
 				continue
@@ -186,24 +184,6 @@ func messagesToSeries(messages []producers.MetricsMessage) *DDSeries {
 	}
 
 	return series
-}
-
-func toFloat64(value interface{}) (float64, error) {
-	switch value := value.(type) {
-	case float64:
-		return value, nil
-	case float32:
-		return float64(value), nil
-	case int64:
-		return float64(value), nil
-	case int32:
-		return float64(value), nil
-	case int:
-		return float64(value), nil
-	case string:
-		return strconv.ParseFloat(value, 64)
-	}
-	return math.NaN(), fmt.Errorf("Could not convert %+v (%T) to float64", value, value)
 }
 
 func parseTimestamp(timestamp string) (*time.Time, error) {

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -122,7 +122,7 @@ type DDResult struct {
 func main() {
 	log.Info("Starting Standalone DataDog DC/OS metrics plugin")
 	datadogPlugin, err := plugin.New(
-		plugin.PluginName("standalone-datadog"),
+		plugin.Name("standalone-datadog"),
 		plugin.ExtraFlags(pluginFlags),
 		plugin.ConnectorFunc(datadogConnector))
 

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -17,11 +17,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	plugin "github.com/dcos/dcos-metrics/plugins"
@@ -153,7 +151,8 @@ func messagesToSeries(messages []producers.MetricsMessage) *DDSeries {
 		addMessageTag("hostname", dimensions.Hostname)
 
 		for _, datapoint := range message.Datapoints {
-			t, err := parseTimestamp(datapoint.Timestamp)
+			t, err := plugin.ParseDatapointTimestamp(datapoint.Timestamp)
+
 			if err != nil {
 				log.Errorf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err)
 				continue
@@ -184,15 +183,4 @@ func messagesToSeries(messages []producers.MetricsMessage) *DDSeries {
 	}
 
 	return series
-}
-
-func parseTimestamp(timestamp string) (*time.Time, error) {
-	if timestamp == "" {
-		return nil, errors.New("Received an empty timestamp")
-	}
-	parsed, err := time.Parse(time.RFC3339, timestamp)
-	if err != nil {
-		return nil, err
-	}
-	return &parsed, nil
 }

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -52,15 +52,17 @@ var (
 
 			res, err := http.Post(datadogURL, "application/json; charset=utf-8", b)
 			if err != nil {
-				log.Error(err)
+				log.Errorf("Could not post payload to DataDog: %v", err)
 				return nil
 			}
+
 			defer res.Body.Close()
 			body, err := ioutil.ReadAll(res.Body)
 			if err != nil {
-				log.Error(err)
+				log.Errorf("Could not read response: %v", err)
 				return nil
 			}
+
 			result := DDResult{}
 			err = json.Unmarshal(body, &result)
 			if err != nil {

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -81,33 +81,34 @@ func main() {
 func datadogConnector(metrics []producers.MetricsMessage, c *cli.Context) error {
 	if len(metrics) == 0 {
 		log.Info("No messages received from metrics service")
-	} else {
-		log.Info("Transmitting metrics to DataDog")
-		datadogURL := fmt.Sprintf("https://app.datadoghq.com/api/v1/series?api_key=%s", c.String("datadog-key"))
+		return nil
+	}
 
-		series := messagesToSeries(metrics)
-		result, err := postSeriesToDatadog(datadogURL, series)
-		if err != nil {
-			return err
-		}
+	log.Info("Transmitting metrics to DataDog")
+	datadogURL := fmt.Sprintf("https://app.datadoghq.com/api/v1/series?api_key=%s", c.String("datadog-key"))
 
-		if len(result.Errors) > 0 {
-			log.Error("Encountered errors:")
-			for _, err := range result.Errors {
-				log.Error(err)
-			}
+	series := messagesToSeries(metrics)
+	result, err := postSeriesToDatadog(datadogURL, series)
+	if err != nil {
+		return err
+	}
+
+	if len(result.Errors) > 0 {
+		log.Error("Encountered errors:")
+		for _, err := range result.Errors {
+			log.Error(err)
 		}
-		if len(result.Warnings) > 0 {
-			log.Warn("Encountered warnings:")
-			for _, wrn := range result.Warnings {
-				log.Warn(wrn)
-			}
+	}
+	if len(result.Warnings) > 0 {
+		log.Warn("Encountered warnings:")
+		for _, wrn := range result.Warnings {
+			log.Warn(wrn)
 		}
-		if result.Status == "ok" {
-			log.Info("Successfully transmitted metrics")
-		} else if result.Status != "" {
-			log.Warnf("Expected status to be ok, actually: %v", result.Status)
-		}
+	}
+	if result.Status == "ok" {
+		log.Info("Successfully transmitted metrics")
+	} else if result.Status != "" {
+		log.Warnf("Expected status to be ok, actually: %v", result.Status)
 	}
 
 	return nil

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -83,6 +83,8 @@ var (
 			}
 			if result.Status == "ok" {
 				log.Info("Successfully transmitted metrics")
+			} else if result.Status != nil {
+				log.Warnf("Expected status to be ok, actually: %v", result.Status)
 			}
 		}
 

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -90,11 +90,11 @@ var (
 	}
 )
 
-// DataPoint is a tuple of [UNIX timestamp, value]. This has to use floats
+// DDDataPoint is a tuple of [UNIX timestamp, value]. This has to use floats
 // because the value could be non-integer.
 type DDDataPoint [2]float64
 
-// Metric represents a collection of data points that we might send or receive
+// DDMetric represents a collection of data points that we might send or receive
 // on one single metric line.
 type DDMetric struct {
 	Metric string        `json:"metric,omitempty"`
@@ -105,12 +105,12 @@ type DDMetric struct {
 	Unit   string        `json:"unit,omitempty"`
 }
 
-// Series represents a collection of data points we get when we query for timeseries data
+// DDSeries represents a collection of data points we get when we query for timeseries data
 type DDSeries struct {
 	Series []DDMetric `json:"series"`
 }
 
-// A successful metrics API result
+// DDResult represents the result from a DataDog API Query
 type DDResult struct {
 	Status   string   `json:"status,omitempty"`
 	Errors   []string `json:"errors,omitempty"`

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -83,7 +83,7 @@ var (
 			}
 			if result.Status == "ok" {
 				log.Info("Successfully transmitted metrics")
-			} else if result.Status != nil {
+			} else if result.Status != "" {
 				log.Warnf("Expected status to be ok, actually: %v", result.Status)
 			}
 		}

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -17,7 +17,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -118,18 +117,18 @@ func postMetricsToDatadog(datadogURL string, metrics []producers.MetricsMessage)
 	b := new(bytes.Buffer)
 	err := json.NewEncoder(b).Encode(series)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not encode metrics to JSON: %v", err))
+		return nil, fmt.Errorf("Could not encode metrics to JSON: %v", err)
 	}
 
 	res, err := http.Post(datadogURL, "application/json; charset=utf-8", b)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not post payload to DataDog: %v", err))
+		return nil, fmt.Errorf("Could not post payload to DataDog: %v", err)
 	}
 
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not read response: %v", err))
+		return nil, fmt.Errorf("Could not read response: %v", err)
 	}
 
 	result := DDResult{}
@@ -182,7 +181,7 @@ func messagesToSeries(messages []producers.MetricsMessage) *DDSeries {
 func datapointToDDMetric(datapoint producers.Datapoint, messageTags []string, host *string) (*DDMetric, error) {
 	t, err := plugin.ParseDatapointTimestamp(datapoint.Timestamp)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err))
+		return nil, fmt.Errorf("Could not parse timestamp '%s': %v", datapoint.Timestamp, err)
 	}
 
 	v, err := plugin.DatapointValueToFloat64(datapoint.Value)

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -43,7 +43,13 @@ var (
 
 			s := messagesToSeries(metrics)
 			b := new(bytes.Buffer)
-			json.NewEncoder(b).Encode(s)
+
+			err := json.NewEncoder(b).Encode(s)
+			if err != nil {
+				log.Errorf("Could not encode metrics to JSON: %v", err)
+				return nil
+			}
+
 			res, err := http.Post(datadogURL, "application/json; charset=utf-8", b)
 			if err != nil {
 				log.Error(err)

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -36,7 +36,7 @@ var (
 	}
 	datadogConnector = func(metrics []producers.MetricsMessage, c *cli.Context) error {
 		if len(metrics) == 0 {
-			log.Error("No messages received from metrics service")
+			log.Info("No messages received from metrics service")
 		} else {
 			log.Info("Transmitting metrics to DataDog")
 			datadogURL := fmt.Sprintf("https://app.datadoghq.com/api/v1/series?api_key=%s", c.String("datadog-key"))
@@ -58,7 +58,7 @@ var (
 			defer res.Body.Close()
 			body, err := ioutil.ReadAll(res.Body)
 			if err != nil {
-				log.Fatal(err)
+				log.Error(err)
 				return nil
 			}
 			result := DDResult{}

--- a/plugins/datadog-standalone/datadog-standalone_test.go
+++ b/plugins/datadog-standalone/datadog-standalone_test.go
@@ -41,7 +41,10 @@ var (
 
 func TestPostMetricsToDatadog(t *testing.T) {
 	nodeMetrics := producers.MetricsMessage{}
-	json.Unmarshal([]byte(nodeMetricsJSON), &nodeMetrics)
+	err := json.Unmarshal([]byte(nodeMetricsJSON), &nodeMetrics)
+	if err != nil {
+		t.Fatal("Bad test fixture; could not unmarshal JSON")
+	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()

--- a/plugins/datadog-standalone/datadog-standalone_test.go
+++ b/plugins/datadog-standalone/datadog-standalone_test.go
@@ -92,5 +92,7 @@ func TestPostMetricsToDatadog(t *testing.T) {
 		}
 
 	}))
+
+	defer server.Close()
 	postMetricsToDatadog(server.URL, []producers.MetricsMessage{nodeMetrics})
 }

--- a/plugins/datadog-standalone/datadog-standalone_test.go
+++ b/plugins/datadog-standalone/datadog-standalone_test.go
@@ -18,7 +18,6 @@ import "net/http"
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http/httptest"
 	"testing"
 
@@ -83,12 +82,12 @@ func TestPostMetricsToDatadog(t *testing.T) {
 				}
 			}
 			if !tagWasFound {
-				log.Fatalf("Expected to find tag %s, but it was not present", expectedTag)
+				t.Fatalf("Expected to find tag %s, but it was not present", expectedTag)
 			}
 		}
 
 		if *uptime.Host != "192.168.65.90" {
-			log.Fatalf("Expected to find host 192.168.65.90, found %s", uptime.Host)
+			t.Fatalf("Expected to find host 192.168.65.90, found %s", uptime.Host)
 		}
 
 	}))

--- a/plugins/datadog-standalone/datadog-standalone_test.go
+++ b/plugins/datadog-standalone/datadog-standalone_test.go
@@ -1,0 +1,96 @@
+// Copyright 2017 Mesosphere, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "net/http"
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dcos/dcos-metrics/producers"
+)
+
+var (
+	nodeMetricsJSON = `{
+		"datapoints":[
+			{"name":"system.uptime","value":86799,"unit":"count","timestamp":"2017-04-08T20:37:39.259136472Z", "tags":{"foo":"bar"}},
+			{"name":"cpu.cores","value":2,"unit":"count","timestamp":"2017-04-08T20:37:39.259145164Z"},
+			{"name":"cpu.total","value":1.32,"unit":"percent","timestamp":"2017-04-08T20:37:39.259145164Z"}
+		],
+		"dimensions":{
+			"mesos_id":"378922ca-dd97-4802-a1b2-dde2f42d74ac",
+			"cluster_id":"cc477141-2c93-4b9f-bf05-ec0e163ce2bd",
+			"hostname":"192.168.65.90"
+		}
+	}`
+)
+
+func TestPostMetricsToDatadog(t *testing.T) {
+	nodeMetrics := producers.MetricsMessage{}
+	json.Unmarshal([]byte(nodeMetricsJSON), &nodeMetrics)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("Could not read request body: %s", err)
+		}
+
+		var series = &DDSeries{}
+		if err := json.Unmarshal(b, &series); err != nil {
+			t.Fatal(err)
+		}
+
+		if len(series.Series) != 3 {
+			t.Fatalf("Expected 3 datapoints, got %d", len(series.Series))
+		}
+
+		uptime := series.Series[0]
+		if uptime.Points[0][0] != 1491683859 {
+			t.Fatalf("Expected unix time of 1491683859, got %v", uptime.Points[0])
+		}
+
+		expectedTags := []string{
+			// message-level tags
+			"mesosId:378922ca-dd97-4802-a1b2-dde2f42d74ac",
+			"clusterId:cc477141-2c93-4b9f-bf05-ec0e163ce2bd",
+			"hostname:192.168.65.90",
+			// metric-level tag
+			"foo:bar",
+		}
+
+		for _, expectedTag := range expectedTags {
+			tagWasFound := false
+			for _, tag := range uptime.Tags {
+				if expectedTag == tag {
+					tagWasFound = true
+					break
+				}
+			}
+			if !tagWasFound {
+				log.Fatalf("Expected to find tag %s, but it was not present", expectedTag)
+			}
+		}
+
+		if *uptime.Host != "192.168.65.90" {
+			log.Fatalf("Expected to find host 192.168.65.90, found %s", uptime.Host)
+		}
+
+	}))
+	postMetricsToDatadog(server.URL, []producers.MetricsMessage{nodeMetrics})
+}

--- a/plugins/datadog-standalone/datadog-standalone_test.go
+++ b/plugins/datadog-standalone/datadog-standalone_test.go
@@ -41,8 +41,7 @@ var (
 
 func TestPostMetricsToDatadog(t *testing.T) {
 	nodeMetrics := producers.MetricsMessage{}
-	err := json.Unmarshal([]byte(nodeMetricsJSON), &nodeMetrics)
-	if err != nil {
+	if err := json.Unmarshal([]byte(nodeMetricsJSON), &nodeMetrics); err != nil {
 		t.Fatal("Bad test fixture; could not unmarshal JSON")
 	}
 


### PR DESCRIPTION
This PR adds a plugin for DataDog which does not rely on the datadog-agent to receive or send stats. 

The included [Readme](https://github.com/dcos/dcos-metrics/blob/dff3a6f6f9895841b75859dc840a769bbaa987e2/plugins/datadog-standalone/README.md) contains details on how to use the plugin.

This is useful in situations where you:
1. Don't want the datadog-agent running on every node
1. Want to send stats to datadog directly from each node