### PR TITLE
Changed test to check for monotonically increasing cpu time values.

### DIFF
--- a/collectors/node/cpu_test.go
+++ b/collectors/node/cpu_test.go
@@ -149,8 +149,8 @@ func TestGetCPUTimes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			So(cur.User, ShouldBeGreaterThan, last.User)
-			So(cur.Idle, ShouldBeGreaterThan, last.Idle)
+			So(cur.User, ShouldBeGreaterThanOrEqualTo, last.User)
+			So(cur.Idle, ShouldBeGreaterThanOrEqualTo, last.Idle)
 		})
 	})
 }


### PR DESCRIPTION
This fixes an issue where the test was checking that the cpu ticks had to always be increasing between samplings.  Because the counter is monotonically increasing is it understood that this value may not change between samplings.  Therefore, the test should allow values that are equal to each other.