### PR TITLE
Fix store cache expiry, fixing stale data bug

### DIFF
--- a/config.go
+++ b/config.go
@@ -222,6 +222,15 @@ func getNewConfig(args []string) (Config, error) {
 		return c, fmt.Errorf("error: expected role to be 'master' or 'agent, got: %s", c.DCOSRole)
 	}
 
+	// Ensure that data is collected from the Mesos Agent more
+	// regularly than it is evicted from the cache, to avoid
+	// missing data for long-running tasks
+	minCacheExpiry := c.Collector.MesosAgent.PollPeriod * 2
+	if c.Producers.HTTPProducerConfig.CacheExpiry < minCacheExpiry {
+		log.Warnf("Configured HTTPProducer.CacheExpiry value was too low. It has been overridden to %v", minCacheExpiry)
+		c.Producers.HTTPProducerConfig.CacheExpiry = minCacheExpiry
+	}
+
 	// Note: .getNodeInfo() is last so we are sure we have all the
 	// configuration we need from flags and config file to make
 	// this run correctly.
@@ -237,15 +246,5 @@ func getNewConfig(args []string) (Config, error) {
 	}
 
 	c.Collector.MesosAgent.HTTPClient = collectorClient
-
-	// Ensure that data is collected from the Mesos Agent more
-	// regularly than it is evicted from the cache, to avoid
-	// missing data for long-running tasks
-	minCacheExpiry := c.Collector.MesosAgent.PollPeriod * 2
-	if c.Producers.HTTPProducerConfig.CacheExpiry < minCacheExpiry {
-		log.Warnf("Configured HTTPProducer.CacheExpiry value was too low. It has been overridden to %v", minCacheExpiry)
-		c.Producers.HTTPProducerConfig.CacheExpiry = minCacheExpiry
-	}
-
 	return c, nil
 }

--- a/config.go
+++ b/config.go
@@ -238,5 +238,14 @@ func getNewConfig(args []string) (Config, error) {
 
 	c.Collector.MesosAgent.HTTPClient = collectorClient
 
+	// Ensure that data is collected from the Mesos Agent more
+	// regularly than it is evicted from the cache, to avoid
+	// missing data for long-running tasks
+	minCacheExpiry := c.Collector.MesosAgent.PollPeriod * 2
+	if c.Producers.HTTPProducerConfig.CacheExpiry < minCacheExpiry {
+		log.Warnf("Configured HTTPProducer.CacheExpiry value was too low. It has been overridden to %v", minCacheExpiry)
+		c.Producers.HTTPProducerConfig.CacheExpiry = minCacheExpiry
+	}
+
 	return c, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -50,6 +50,10 @@ func TestNewConfig(t *testing.T) {
 		Convey("Default HTTP producer port should be 9000", func() {
 			So(testConfig.Producers.HTTPProducerConfig.Port, ShouldEqual, 9000)
 		})
+
+		Convey("Default cache expiry should be 2 minutes", func() {
+			So(testConfig.Producers.HTTPProducerConfig.CacheExpiry, ShouldEqual, 120*time.Second)
+		})
 	})
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -131,7 +131,7 @@ collector:
     poll_period: 90s
 `))
 	defer teardown()
-	testConfig, err := getNewConfig([]string{"-role", "agent", "-config", tmpConfig.Name()})
+	testConfig, _ := getNewConfig([]string{"-role", "agent", "-config", tmpConfig.Name()})
 
 	Convey("When getting the service configuration", t, func() {
 		Convey("Should error if the user did not specify exactly one role (master or agent)", func() {
@@ -145,7 +145,9 @@ collector:
 			})
 		})
 		Convey("Should ensure that the cache expiry is not less than twice the poll period", func() {
-			So(err, ShouldBeNil)
+			// Note that this returns an error in environments which are missing the
+			// /opt/mesosphere/bin/detect_ip script, eg CI
+			// TODO(philip) mock calls to FileDetctIP
 			So(testConfig.Producers.HTTPProducerConfig.CacheExpiry, ShouldEqual, 180*time.Second)
 		})
 

--- a/dcos-metrics.go
+++ b/dcos-metrics.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -58,7 +57,12 @@ func main() {
 	if producerIsConfigured("http", cfg) {
 		log.Info("HTTP producer enabled")
 		cfg.Producers.HTTPProducerConfig.DCOSRole = cfg.DCOSRole
-		cfg.Producers.HTTPProducerConfig.CacheExpiry = time.Duration(cfg.Collector.MesosAgent.PollPeriod) * time.Minute * 2
+
+		minCacheExpiry := cfg.Collector.MesosAgent.PollPeriod * 2
+		if cfg.Producers.HTTPProducerConfig.CacheExpiry < minCacheExpiry {
+			log.Warnf("Configured HTTPProducer.CacheExpiry value was too low. It has been overridden to %v", minCacheExpiry)
+			cfg.Producers.HTTPProducerConfig.CacheExpiry = minCacheExpiry
+		}
 
 		hp, httpProducerChan := httpProducer.New(
 			cfg.Producers.HTTPProducerConfig)

--- a/dcos-metrics.go
+++ b/dcos-metrics.go
@@ -58,12 +58,6 @@ func main() {
 		log.Info("HTTP producer enabled")
 		cfg.Producers.HTTPProducerConfig.DCOSRole = cfg.DCOSRole
 
-		minCacheExpiry := cfg.Collector.MesosAgent.PollPeriod * 2
-		if cfg.Producers.HTTPProducerConfig.CacheExpiry < minCacheExpiry {
-			log.Warnf("Configured HTTPProducer.CacheExpiry value was too low. It has been overridden to %v", minCacheExpiry)
-			cfg.Producers.HTTPProducerConfig.CacheExpiry = minCacheExpiry
-		}
-
 		hp, httpProducerChan := httpProducer.New(
 			cfg.Producers.HTTPProducerConfig)
 		producerChans = append(producerChans, httpProducerChan)

--- a/examples/configs/dcos-metrics-config-example.yaml
+++ b/examples/configs/dcos-metrics-config-example.yaml
@@ -7,10 +7,10 @@ collector:
   http_profiler: false
   
   node:
-    poll_period: 15 
+    poll_period: 15s
 
   mesos_agent:
-    poll_period: 15
+    poll_period: 15s
     port: 5051
     request_protocol: http
 


### PR DESCRIPTION
There was a nasty bug in the metrics package where the cache expiry period was set to 189 years instead of two minutes. 

This PR:-
 - [x] fixes the expiry period
 - [x] adds a test to ensure that this does not occur again
 - [x] corrects the values in the configuration yaml