### PR TITLE
Fix NaN errors in traces

### DIFF
--- a/collectors/framework/framework.go
+++ b/collectors/framework/framework.go
@@ -17,7 +17,9 @@ package framework
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
+	"math"
 	"net"
 	"time"
 
@@ -218,6 +220,31 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 	dps, err := record.Get("datapoints")
 	if err != nil {
 		return pmm, err
+	}
+
+	decodedDps, ok := dps.([]interface{})
+	if !ok {
+		return pmm, fmt.Errorf("Could not decode datapoints %v", dps)
+	}
+
+	for _, dp := range decodedDps {
+		dpr, ok := dp.(*goavro.Record)
+		if !ok {
+			fwColLog.Debugf("Bad datapoint record encountered: %v", dp)
+			continue
+		}
+		value, err := dpr.Get("dcos.metrics.value")
+		if err != nil {
+			fwColLog.Debugf("Datum without value encountered: %v", dpr)
+			continue
+		}
+		// Avoid marshalling to JSON with NaN values, which
+		// chokes the go json library.
+		if v, ok := value.(float64); ok {
+			if math.IsNaN(v) {
+				dpr.Set("dcos.metrics.value", "NaN")
+			}
+		}
 	}
 
 	if err := datapointData.createObjectFromRecord(dps); err != nil {

--- a/collectors/framework/framework.go
+++ b/collectors/framework/framework.go
@@ -227,13 +227,14 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 		return pmm, fmt.Errorf("Could not decode datapoints %v", dps)
 	}
 
+	const metricsValueKey = "dcos.metrics.value"
 	for _, dp := range decodedDps {
 		dpr, ok := dp.(*goavro.Record)
 		if !ok {
 			fwColLog.Debugf("Bad datapoint record encountered: %v", dp)
 			continue
 		}
-		value, err := dpr.Get("dcos.metrics.value")
+		value, err := dpr.Get(metricsValueKey)
 		if err != nil {
 			fwColLog.Debugf("Datum without value encountered: %v", dpr)
 			continue
@@ -242,7 +243,7 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 		// chokes the go json library.
 		if v, ok := value.(float64); ok {
 			if math.IsNaN(v) {
-				dpr.Set("dcos.metrics.value", "NaN")
+				dpr.Set(metricsValueKey, "NaN")
 			}
 		}
 	}

--- a/collectors/framework/framework_test.go
+++ b/collectors/framework/framework_test.go
@@ -149,7 +149,7 @@ func TestTransform(t *testing.T) {
 			if err != nil {
 				panic(err)
 			}
-			recNan.Set("name", "some-name")
+			recNan.Set("name", "nan-name")
 			recNan.Set("time_ms", 1000)
 			recNan.Set("value", math.NaN())
 
@@ -166,7 +166,7 @@ func TestTransform(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(pmm, ShouldHaveSameTypeAs, producers.MetricsMessage{})
 
-			So(pmm.Datapoints[0].Name, ShouldEqual, "some-name")
+			So(pmm.Datapoints[0].Name, ShouldEqual, "nan-name")
 			So(pmm.Datapoints[0].Value, ShouldEqual, "NaN")
 			So(pmm.Datapoints[0].Timestamp, ShouldNotEqual, "")
 		})

--- a/collectors/framework/framework_test.go
+++ b/collectors/framework/framework_test.go
@@ -164,11 +164,9 @@ func TestTransform(t *testing.T) {
 			a := AvroDatum{Record: rec, Topic: "some-topic"}
 			pmm, err := a.transform(mockNodeInfo)
 			So(err, ShouldBeNil)
-			So(pmm, ShouldHaveSameTypeAs, producers.MetricsMessage{})
 
 			So(pmm.Datapoints[0].Name, ShouldEqual, "nan-name")
 			So(pmm.Datapoints[0].Value, ShouldEqual, "NaN")
-			So(pmm.Datapoints[0].Timestamp, ShouldNotEqual, "")
 		})
 	})
 }

--- a/collectors/framework/record.go
+++ b/collectors/framework/record.go
@@ -106,11 +106,12 @@ func (ar avroRecord) extract(pmm *producers.MetricsMessage) error {
 // *avroRecord.createObjectFromRecord creates a JSON implementation of the avro
 // record, then serializes it to our known avroRecord type.
 func (ar *avroRecord) createObjectFromRecord(record interface{}) error {
-	jsonObj, err := json.MarshalIndent(record, "", "    ")
+	jsonObj, err := json.Marshal(record)
 	if err != nil {
+		fwColLog.Debugf("Bad record:\n%s", record)
 		return err
 	}
 
-	fwColLog.Debug("JSON Record:\n", string(jsonObj))
+	fwColLog.Debugf("JSON Record:\n%s", string(jsonObj))
 	return json.Unmarshal(jsonObj, &ar)
 }

--- a/collectors/framework/record_test.go
+++ b/collectors/framework/record_test.go
@@ -17,7 +17,6 @@
 package framework
 
 import (
-	"math"
 	"testing"
 
 	"github.com/dcos/dcos-metrics/producers"
@@ -140,14 +139,6 @@ func TestCreateObjectFromRecord(t *testing.T) {
 	recDps.Set("time_ms", 1000)
 	recDps.Set("value", 42.0)
 
-	recNan, err := goavro.NewRecord(datapointNamespace, datapointSchema)
-	if err != nil {
-		panic(err)
-	}
-	recDps.Set("name", "nan-name")
-	recDps.Set("time_ms", 1000)
-	recDps.Set("value", math.NaN())
-
 	recTags, err := goavro.NewRecord(tagNamespace, tagSchema)
 	if err != nil {
 		panic(err)
@@ -203,28 +194,6 @@ func TestCreateObjectFromRecord(t *testing.T) {
 			ar := avroRecord{}
 			err := ar.createObjectFromRecord(bd)
 			So(err, ShouldNotBeNil)
-		})
-
-		Convey("Should drop well-formed datapoints with NaN values", func() {
-			ar := avroRecord{}
-			err = ar.createObjectFromRecord([]interface{}{recDps, recNan})
-
-			So(err, ShouldBeNil)
-			So(ar, ShouldResemble, avroRecord{
-				record{
-					Name: "dcos.metrics.Datapoint",
-					Fields: []field{
-						field{
-							Name:  "dcos.metrics.name",
-							Datum: "some-key",
-						},
-						field{
-							Name:  "dcos.metrics.value",
-							Datum: 42.0,
-						},
-					},
-				},
-			})
 		})
 	})
 }


### PR DESCRIPTION
At present, we're doing something pretty evil: coercing data into structs by marshalling it to JSON (which uses `reflect` internally 😱) and then unmarshalling it again to `producer.MetricsMessage`:
https://github.com/dcos/dcos-metrics/blob/master/collectors/framework/record.go#L106-L116

This is choking on datapoints which have `NaN` values, which is, in a word, [unfortunate](https://github.com/golang/go/issues/3480#issuecomment-66066048). 

