### PR TITLE
Handle errors gracefully

### DIFF
--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -88,7 +88,8 @@ func datadogConnector(metrics []producers.MetricsMessage, c *cli.Context) error 
 
 	result, err := postMetricsToDatadog(datadogURL, metrics)
 	if err != nil {
-		return err
+		log.Errorf("Unexpected error while processing DataDog response: %v", err)
+		return nil
 	}
 
 	if len(result.Errors) > 0 {
@@ -134,6 +135,7 @@ func postMetricsToDatadog(datadogURL string, metrics []producers.MetricsMessage)
 	result := DDResult{}
 	err = json.Unmarshal(body, &result)
 	if err != nil {
+		log.Warnf("Unreadable DataDog output: %s", body)
 		return nil, err
 	}
 	return &result, nil

--- a/plugins/datadog-standalone/datadog-standalone.go
+++ b/plugins/datadog-standalone/datadog-standalone.go
@@ -88,7 +88,7 @@ func datadogConnector(metrics []producers.MetricsMessage, c *cli.Context) error 
 
 	result, err := postMetricsToDatadog(datadogURL, metrics)
 	if err != nil {
-		log.Errorf("Unexpected error while processing DataDog response: %v", err)
+		log.Errorf("Unexpected error while processing DataDog response: %s", err)
 		return nil
 	}
 
@@ -135,7 +135,7 @@ func postMetricsToDatadog(datadogURL string, metrics []producers.MetricsMessage)
 	result := DDResult{}
 	err = json.Unmarshal(body, &result)
 	if err != nil {
-		log.Warnf("Unreadable DataDog output: %s", body)
+		log.Warnf("Could not unmarshal datadog response %s: %s", body, err)
 		return nil, err
 	}
 	return &result, nil

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -141,9 +141,12 @@ func (p *Plugin) StartPlugin() error {
 // Metrics polls the DC/OS components and returns a slice of
 // producers.MetricsMessage.
 func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
-	p.Log.Info("Getting metrics from metrics service")
 	metricsMessages := []producers.MetricsMessage{}
+	if len(p.AuthToken) == 0 {
+		return metricsMessages, errors.New("Auth token must be set, use --auth-token <token>")
+	}
 
+	p.Log.Info("Getting metrics from metrics service")
 	if err := p.setEndpoints(); err != nil {
 		p.Log.Fatal(err)
 	}
@@ -153,10 +156,6 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 			Scheme: p.MetricsProto,
 			Host:   net.JoinHostPort(p.MetricsHost, p.MetricsPort),
 			Path:   path,
-		}
-
-		if len(p.AuthToken) == 0 {
-			return metricsMessages, errors.New("Auth token must be set, use --auth-token <token>")
 		}
 
 		request := &http.Request{

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -141,11 +141,11 @@ func (p *Plugin) StartPlugin() error {
 // Metrics polls the DC/OS components and returns a slice of
 // producers.MetricsMessage.
 func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
-	metricsMessages := []producers.MetricsMessage{}
 	if len(p.AuthToken) == 0 {
-		return metricsMessages, errors.New("Auth token must be set, use --auth-token <token>")
+		return nil, errors.New("Auth token must be set, use --auth-token <token>")
 	}
 
+	metricsMessages := []producers.MetricsMessage{}
 	p.Log.Info("Getting metrics from metrics service")
 	if err := p.setEndpoints(); err != nil {
 		p.Log.Fatal(err)


### PR DESCRIPTION
This PR prevents the DataDog plugin crashing when a bad result is returned from the DataDog API. 

For example, when a very long tag is sent to DataDog, the API responds with the text 'Payload too big', instead of JSON. Previously the plugin would have crashed with a JSON parse error. It now logs an error and continues to run. 