### PR TITLE
Drop long labels in mesos agent

### DIFF
--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -154,7 +154,7 @@ func getLabelsByContainerID(containerID string, frameworks []frameworkInfo, log 
 				log.Debugf("ContainerID %v for executor %v is a match, adding labels", containerID, executor)
 				for _, pair := range executor.Labels {
 					if len(pair.Value) > maxLabelLength {
-						log.Warnf("Label %s is longer than %d chars; discarding label", maxLabelLength, pair.Key)
+						log.Warnf("Label %s is longer than %d chars; discarding label", pair.Key, maxLabelLength)
 						log.Debugf("Discarded label value: %s", pair.Value)
 						continue
 					}

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -27,7 +27,8 @@ import (
 
 const (
 	// HTTPTIMEOUT defines the maximum duration for all requests
-	HTTPTIMEOUT = 2 * time.Second
+	HTTPTIMEOUT    = 2 * time.Second
+	maxLabelLength = 128
 )
 
 // Collector defines the collector type for Mesos agent. It is
@@ -152,8 +153,8 @@ func getLabelsByContainerID(containerID string, frameworks []frameworkInfo, log 
 			if executor.Container == containerID {
 				log.Debugf("ContainerID %v for executor %v is a match, adding labels", containerID, executor)
 				for _, pair := range executor.Labels {
-					if len(pair.Value) > 128 {
-						log.Warnf("Label %s is longer than 128 chars; discarding label", pair.Key)
+					if len(pair.Value) > maxLabelLength {
+						log.Warnf("Label %s is longer than %d chars; discarding label", maxLabelLength, pair.Key)
 						log.Debugf("Discarded label value: %s", pair.Value)
 					} else {
 						log.Debugf("Adding label for containerID %v: %v = %+v", containerID, pair.Key, pair.Value)

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -146,14 +146,19 @@ func getFrameworkInfoByFrameworkID(frameworkID string, frameworks []frameworkInf
 func getLabelsByContainerID(containerID string, frameworks []frameworkInfo, log *logrus.Entry) map[string]string {
 	labels := map[string]string{}
 	for _, framework := range frameworks {
-		log.Debugf("Attemping to add labels to %v framework", framework)
+		log.Debugf("Attempting to add labels to %v framework", framework)
 		for _, executor := range framework.Executors {
 			log.Debugf("Found executor %v for framework %v", framework, executor)
 			if executor.Container == containerID {
 				log.Debugf("ContainerID %v for executor %v is a match, adding labels", containerID, executor)
 				for _, pair := range executor.Labels {
-					log.Debugf("Adding label for containerID %v: %v = %+v", containerID, pair.Key, pair.Value)
-					labels[pair.Key] = pair.Value
+					if len(pair.Value) > 128 {
+						log.Warnf("Label %s is longer than 128 chars; discarding label", pair.Key)
+						log.Debugf("Discarded label value: %s", pair.Value)
+					} else {
+						log.Debugf("Adding label for containerID %v: %v = %+v", containerID, pair.Key, pair.Value)
+						labels[pair.Key] = pair.Value
+					}
 				}
 				return labels
 			}

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -156,10 +156,10 @@ func getLabelsByContainerID(containerID string, frameworks []frameworkInfo, log 
 					if len(pair.Value) > maxLabelLength {
 						log.Warnf("Label %s is longer than %d chars; discarding label", maxLabelLength, pair.Key)
 						log.Debugf("Discarded label value: %s", pair.Value)
-					} else {
-						log.Debugf("Adding label for containerID %v: %v = %+v", containerID, pair.Key, pair.Value)
-						labels[pair.Key] = pair.Value
+						continue
 					}
+					log.Debugf("Adding label for containerID %v: %v = %+v", containerID, pair.Key, pair.Value)
+					labels[pair.Key] = pair.Value
 				}
 				return labels
 			}

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -379,6 +379,19 @@ func TestGetLabelsByContainerID(t *testing.T) {
 							},
 						},
 					},
+					executorInfo{
+						Container: "containerWithLongLabelID",
+						Labels: []executorLabels{
+							executorLabels{
+								Key:   "somekey",
+								Value: "someval",
+							},
+							executorLabels{
+								Key:   "longkey",
+								Value: "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+							},
+						},
+					},
 				},
 			},
 		}
@@ -391,6 +404,11 @@ func TestGetLabelsByContainerID(t *testing.T) {
 		Convey("Should return an empty map if no labels were present", func() {
 			result := getLabelsByContainerID("someOtherContainerID", fi, tl)
 			So(result, ShouldResemble, map[string]string{})
+		})
+
+		Convey("Should drop labels with overly long values", func() {
+			result := getLabelsByContainerID("containerWithLongLabelID", fi, tl)
+			So(result, ShouldResemble, map[string]string{"somekey": "someval"})
 		})
 	})
 }


### PR DESCRIPTION
This PR introduces a check on the length of label values from Mesos. Any label with a value exceeding 128 characters is dropped with a warning. 

Mesos task labels can be extremely long. This becomes a problem with DC/OS packages where labels are used to carry JSON metadata in base64 format. Each label is transformed to a tag per datapoint, causing unnecessary data inflation.

This became urgent when it increased DataDog metrics payloads above 8kb and caused the API to return errors.