### PR TITLE
Use configurable IAM in preference to JWT token in plugins

### DIFF
--- a/plugins/option.go
+++ b/plugins/option.go
@@ -16,7 +16,6 @@ package plugin
 
 import (
 	"errors"
-	"strconv"
 
 	"github.com/dcos/dcos-metrics/producers"
 	"github.com/urfave/cli"
@@ -56,7 +55,7 @@ func PollingInterval(i int) Option {
 func MetricsProtocol(proto string) Option {
 	return func(p *Plugin) error {
 		if proto == "http" || proto == "https" {
-			p.MetricsProto = proto
+			p.MetricsScheme = proto
 			return nil
 		}
 		return errBadProto
@@ -77,7 +76,7 @@ func MetricsHost(h string) Option {
 func MetricsPort(port int) Option {
 	return func(p *Plugin) error {
 		if port <= 65535 {
-			p.MetricsPort = strconv.Itoa(port)
+			p.MetricsPort = port
 			return nil
 		}
 		return errBadPort

--- a/plugins/option.go
+++ b/plugins/option.go
@@ -84,18 +84,6 @@ func MetricsPort(port int) Option {
 	}
 }
 
-// MetricsAuthToken allows the plugin to set a custom auth token for the
-// Authorization header for the http request that is used to gather metrics.
-func MetricsAuthToken(t string) Option {
-	return func(p *Plugin) error {
-		if len(t) != 0 {
-			p.AuthToken = t
-			return nil
-		}
-		return errBadToken
-	}
-}
-
 // ConnectorFunc is what the plugin framework will call once it has gathered
 // metrics. It is expected that this function will convert these messages to
 // a 3rd party format and then send the metrics to that service.

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -41,7 +42,7 @@ type Plugin struct {
 	Endpoints         []string
 	Role              string
 	PollingInterval   int
-	MetricsPort       string
+	MetricsPort       int
 	MetricsScheme     string
 	MetricsHost       string
 	Log               *logrus.Entry
@@ -62,7 +63,7 @@ func New(options ...Option) (*Plugin, error) {
 		PollingInterval: 10,
 		MetricsScheme:   "http",
 		MetricsHost:     "localhost",
-		MetricsPort:     "61001",
+		MetricsPort:     61001,
 	}
 
 	newPlugin.App = cli.NewApp()
@@ -80,7 +81,7 @@ func New(options ...Option) (*Plugin, error) {
 			Usage:       "The HTTP protocol for the DC/OS metrics service",
 			Destination: &newPlugin.MetricsScheme,
 		},
-		cli.StringFlag{
+		cli.IntFlag{
 			Name:        "metrics-port",
 			Value:       newPlugin.MetricsPort,
 			Usage:       "Port the DC/OS metrics service is running.Defaults to agent adminrouter port",
@@ -166,7 +167,7 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 	for _, path := range p.Endpoints {
 		metricsURL := url.URL{
 			Scheme: p.MetricsScheme,
-			Host:   net.JoinHostPort(p.MetricsHost, p.MetricsPort),
+			Host:   net.JoinHostPort(p.MetricsHost, strconv.Itoa(p.MetricsPort)),
 			Path:   path,
 		}
 
@@ -206,7 +207,7 @@ func (p *Plugin) setEndpoints() error {
 		containers := []string{}
 		metricsURL := url.URL{
 			Scheme: p.MetricsScheme,
-			Host:   net.JoinHostPort(p.MetricsHost, p.MetricsPort),
+			Host:   net.JoinHostPort(p.MetricsHost, strconv.Itoa(p.MetricsPort)),
 			Path:   "/system/v1/metrics/v0/containers",
 		}
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -33,16 +33,17 @@ import (
 // Plugin is used to collect metrics and then send them to a remote system
 // (e.g. DataDog, Librato, etc.).  Use plugin.New(...) to build a new plugin.
 type Plugin struct {
-	App             *cli.App
-	Name            string
-	Endpoints       []string
-	Role            string
-	PollingInterval int
-	MetricsPort     string
-	MetricsProto    string
-	MetricsHost     string
-	Log             *logrus.Entry
-	ConnectorFunc   func([]producers.MetricsMessage, *cli.Context) error
+	App               *cli.App
+	Name              string
+	Endpoints         []string
+	Role              string
+	PollingInterval   int
+	MetricsPort       string
+	MetricsProto      string
+	MetricsHost       string
+	Log               *logrus.Entry
+	ConnectorFunc     func([]producers.MetricsMessage, *cli.Context) error
+	ConfigPath        string
 }
 
 var version = "UNSET"
@@ -51,12 +52,13 @@ var version = "UNSET"
 // metrics will need
 func New(options ...Option) (*Plugin, error) {
 	newPlugin := &Plugin{
-		Name:            "default",
-		Role:            "",
-		PollingInterval: 10,
-		MetricsProto:    "http",
-		MetricsHost:     "localhost",
-		MetricsPort:     "61001",
+		Name:              "default",
+		Role:              "",
+		PollingInterval:   10,
+		MetricsProto:      "http",
+		MetricsHost:       "localhost",
+		MetricsPort:       "61001",
+		ConfigPath:        "",
 	}
 
 	newPlugin.App = cli.NewApp()
@@ -92,6 +94,12 @@ func New(options ...Option) (*Plugin, error) {
 			Value:       newPlugin.Role,
 			Usage:       "DC/OS role, either master or agent",
 			Destination: &newPlugin.Role,
+		},
+		cli.StringFlag{
+			Name:        "config",
+			Value:       newPlugin.ConfigPath,
+			Usage:       "The path to the config file.",
+			Destination: &newPlugin.ConfigPath,
 		},
 	}
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -150,6 +150,18 @@ func (p *Plugin) StartPlugin() error {
 func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 
 	metricsMessages := []producers.MetricsMessage{}
+
+	// The first time Metrics() is called, the plugin client
+	// should be initialised
+	if p.Client == nil {
+		if err := p.loadConfig(); err != nil {
+			return metricsMessages, err
+		}
+		if err := p.createClient(); err != nil {
+			return metricsMessages, err
+		}
+	}
+
 	p.Log.Info("Getting metrics from metrics service")
 	if err := p.setEndpoints(); err != nil {
 		p.Log.Fatal(err)

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -58,15 +58,11 @@ var version = "UNSET"
 // metrics will need
 func New(options ...Option) (*Plugin, error) {
 	newPlugin := &Plugin{
-		Name:              "default",
-		Role:              "",
-		PollingInterval:   10,
-		MetricsProto:      "http",
-		MetricsHost:       "localhost",
-		MetricsPort:       "61001",
-		ConfigPath:        "",
-		IAMConfigPath:     "",
-		CACertificatePath: "",
+		Name:            "default",
+		PollingInterval: 10,
+		MetricsProto:    "http",
+		MetricsHost:     "localhost",
+		MetricsPort:     "61001",
 	}
 
 	newPlugin.App = cli.NewApp()

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-metrics/producers"
+	httpHelpers "github.com/dcos/dcos-metrics/util/http/helpers"
 	"github.com/urfave/cli"
 
 	yaml "gopkg.in/yaml.v2"
@@ -45,6 +46,7 @@ type Plugin struct {
 	MetricsHost       string
 	Log               *logrus.Entry
 	ConnectorFunc     func([]producers.MetricsMessage, *cli.Context) error
+	Client            *http.Client
 	ConfigPath        string
 	IAMConfigPath     string `yaml:"iam_config_path"`
 	CACertificatePath string `yaml:"ca_certificate_path"`
@@ -281,5 +283,18 @@ func (p *Plugin) loadConfig() error {
 		return err
 	}
 
+	return nil
+}
+
+// createClient creates an HTTP Client with credentials (if available) and
+// attaches it to the plugin
+func (p *Plugin) createClient() error {
+	p.Log.Info("Creating an HTTP client to poll the local metrics API")
+	client, err := httpHelpers.NewMetricsClient(p.CACertificatePath, p.IAMConfigPath)
+	if err != nil {
+		return err
+	}
+
+	p.Client = client
 	return nil
 }

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -285,7 +285,7 @@ func (p *Plugin) loadConfig() error {
 		return err
 	}
 
-	if err = yaml.Unmarshal(fileByte, &p); err != nil {
+	if err = yaml.Unmarshal(fileByte, p); err != nil {
 		return err
 	}
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -42,7 +42,7 @@ type Plugin struct {
 	Role              string
 	PollingInterval   int
 	MetricsPort       string
-	MetricsProto      string
+	MetricsScheme     string
 	MetricsHost       string
 	Log               *logrus.Entry
 	ConnectorFunc     func([]producers.MetricsMessage, *cli.Context) error
@@ -60,7 +60,7 @@ func New(options ...Option) (*Plugin, error) {
 	newPlugin := &Plugin{
 		Name:            "default",
 		PollingInterval: 10,
-		MetricsProto:    "http",
+		MetricsScheme:   "http",
 		MetricsHost:     "localhost",
 		MetricsPort:     "61001",
 	}
@@ -76,9 +76,9 @@ func New(options ...Option) (*Plugin, error) {
 		},
 		cli.StringFlag{
 			Name:        "metrics-proto",
-			Value:       newPlugin.MetricsProto,
+			Value:       newPlugin.MetricsScheme,
 			Usage:       "The HTTP protocol for the DC/OS metrics service",
-			Destination: &newPlugin.MetricsProto,
+			Destination: &newPlugin.MetricsScheme,
 		},
 		cli.StringFlag{
 			Name:        "metrics-port",
@@ -165,7 +165,7 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 
 	for _, path := range p.Endpoints {
 		metricsURL := url.URL{
-			Scheme: p.MetricsProto,
+			Scheme: p.MetricsScheme,
 			Host:   net.JoinHostPort(p.MetricsHost, p.MetricsPort),
 			Path:   path,
 		}
@@ -205,7 +205,7 @@ func (p *Plugin) setEndpoints() error {
 
 		containers := []string{}
 		metricsURL := url.URL{
-			Scheme: p.MetricsProto,
+			Scheme: p.MetricsScheme,
 			Host:   net.JoinHostPort(p.MetricsHost, p.MetricsPort),
 			Path:   "/system/v1/metrics/v0/containers",
 		}

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -179,7 +179,7 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 			URL:    &metricsURL,
 		}
 
-		metricMessage, err := makeMetricsRequest(request)
+		metricMessage, err := makeMetricsRequest(p.Client, request)
 		if err != nil {
 			return metricsMessages, err
 		}
@@ -248,11 +248,10 @@ func (p *Plugin) setEndpoints() error {
 }
 
 /*** Helpers ***/
-func makeMetricsRequest(request *http.Request) (producers.MetricsMessage, error) {
+func makeMetricsRequest(client *http.Client, request *http.Request) (producers.MetricsMessage, error) {
 	l := logrus.WithFields(logrus.Fields{"plugin": "http-helper"})
 
 	l.Infof("Making request to %+v", request.URL)
-	client := &http.Client{}
 	mm := producers.MetricsMessage{}
 
 	resp, err := client.Do(request)

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -266,6 +266,11 @@ func makeMetricsRequest(request *http.Request) (producers.MetricsMessage, error)
 // loadConfig loads the CACertPath and IAMConfig from the specified yaml file
 // into the corresponding Plugin struct fields
 func (p *Plugin) loadConfig() error {
+	// ConfigPath is optional; don't attempt to read it if not supplied
+	if p.ConfigPath == "" {
+		p.Log.Info("No --config flag was supplied; metrics requests will not be authenticated and may fail")
+		return nil
+	}
 	p.Log.Info("Loading optional authentication configuration")
 	fileByte, err := ioutil.ReadFile(p.ConfigPath)
 	if err != nil {

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -219,8 +219,7 @@ func (p *Plugin) setEndpoints() error {
 			URL:    &metricsURL,
 		}
 
-		client := &http.Client{}
-		resp, err := client.Do(request)
+		resp, err := p.Client.Do(request)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `--auth-token` parameter previously used by plugins was not a good strategy. If the token expired (in DC/OS configurations which use JWTs, they regularly last five days), the plugin would stop working simultaneously on every node and report errors. The only way to make it work again was to refresh the configuration and restart it. 

With this PR, plugins take a `--config` flag similar to the `--config` flag passed to the dcos-metrics collector, which points to a YAML file with IAM-related information. The plugin loads the file in and uses its contents to authenticate the HTTP client which makes requests against the dcos-metrics API. 