### PR TITLE
Accept sequential statsd input on app metrics channel

### DIFF
--- a/collectors/framework/framework.go
+++ b/collectors/framework/framework.go
@@ -256,6 +256,23 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 		return pmm, err
 	}
 
+	// Convert message-level labels to datapoint-level tags
+	labels := pmm.Dimensions.Labels
+	if labels != nil {
+		for n, d := range pmm.Datapoints {
+			tt := make(map[string]string)
+			// TODO(philip) account for tag/label collision
+			for k, v := range d.Tags {
+				tt[k] = v
+			}
+			for k, v := range labels {
+				tt[k] = v
+			}
+			pmm.Datapoints[n].Tags = tt
+		}
+	}
+	pmm.Dimensions.Labels = nil
+
 	return pmm, nil
 }
 

--- a/collectors/framework/framework.go
+++ b/collectors/framework/framework.go
@@ -257,19 +257,16 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 	}
 
 	// Convert message-level labels to datapoint-level tags
-	labels := pmm.Dimensions.Labels
-	if labels != nil {
-		for i, datapoint := range pmm.Datapoints {
-			tt := make(map[string]string)
-			// TODO(philip) account for tag/label collision
-			for k, v := range datapoint.Tags {
-				tt[k] = v
-			}
-			for k, v := range labels {
-				tt[k] = v
-			}
-			pmm.Datapoints[i].Tags = tt
+	for i, datapoint := range pmm.Datapoints {
+		tt := make(map[string]string)
+		// TODO(philip) account for tag/label collision
+		for k, v := range datapoint.Tags {
+			tt[k] = v
 		}
+		for k, v := range pmm.Dimensions.Labels {
+			tt[k] = v
+		}
+		pmm.Datapoints[i].Tags = tt
 	}
 	pmm.Dimensions.Labels = nil
 

--- a/collectors/framework/framework.go
+++ b/collectors/framework/framework.go
@@ -260,10 +260,10 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 	for i, datapoint := range pmm.Datapoints {
 		tt := make(map[string]string)
 		// TODO(philip) account for tag/label collision
-		for k, v := range datapoint.Tags {
+		for k, v := range pmm.Dimensions.Labels {
 			tt[k] = v
 		}
-		for k, v := range pmm.Dimensions.Labels {
+		for k, v := range datapoint.Tags {
 			tt[k] = v
 		}
 		pmm.Datapoints[i].Tags = tt

--- a/collectors/framework/framework.go
+++ b/collectors/framework/framework.go
@@ -259,11 +259,13 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 	// Convert message-level labels to datapoint-level tags
 	for i, datapoint := range pmm.Datapoints {
 		tt := make(map[string]string)
-		// TODO(philip) account for tag/label collision
 		for k, v := range pmm.Dimensions.Labels {
 			tt[k] = v
 		}
 		for k, v := range datapoint.Tags {
+			if tt[k] != "" {
+				fwColLog.Warnf("Datapoint label '%s' (%s) overridden to %s", k, tt[k], v)
+			}
 			tt[k] = v
 		}
 		pmm.Datapoints[i].Tags = tt

--- a/collectors/framework/framework.go
+++ b/collectors/framework/framework.go
@@ -259,16 +259,16 @@ func (a *AvroDatum) transform(nodeInfo collectors.NodeInfo) (producers.MetricsMe
 	// Convert message-level labels to datapoint-level tags
 	labels := pmm.Dimensions.Labels
 	if labels != nil {
-		for n, d := range pmm.Datapoints {
+		for i, datapoint := range pmm.Datapoints {
 			tt := make(map[string]string)
 			// TODO(philip) account for tag/label collision
-			for k, v := range d.Tags {
+			for k, v := range datapoint.Tags {
 				tt[k] = v
 			}
 			for k, v := range labels {
 				tt[k] = v
 			}
-			pmm.Datapoints[n].Tags = tt
+			pmm.Datapoints[i].Tags = tt
 		}
 	}
 	pmm.Dimensions.Labels = nil

--- a/collectors/framework/framework_test.go
+++ b/collectors/framework/framework_test.go
@@ -110,6 +110,7 @@ func TestTransform(t *testing.T) {
 			So(pmm.Dimensions.MesosID, ShouldEqual, "some-mesos-id")
 			So(pmm.Dimensions.ClusterID, ShouldEqual, "some-cluster-id")
 			So(pmm.Dimensions.Hostname, ShouldEqual, "some-hostname")
+			So(pmm.Dimensions.Labels, ShouldEqual, nil)
 		})
 
 		Convey("Should return an error if AvroDatum didn't contain a goavro.Record", func() {

--- a/collectors/framework/framework_test.go
+++ b/collectors/framework/framework_test.go
@@ -106,10 +106,10 @@ func TestTransform(t *testing.T) {
 			So(pmm.Datapoints[0].Name, ShouldEqual, "some-name")
 			So(pmm.Datapoints[0].Value, ShouldEqual, 42.0)
 			So(pmm.Datapoints[0].Timestamp, ShouldNotEqual, "")
+			So(pmm.Datapoints[0].Tags, ShouldResemble, map[string]string{"some-key": "some-val"})
 			So(pmm.Dimensions.MesosID, ShouldEqual, "some-mesos-id")
 			So(pmm.Dimensions.ClusterID, ShouldEqual, "some-cluster-id")
 			So(pmm.Dimensions.Hostname, ShouldEqual, "some-hostname")
-			So(pmm.Dimensions.Labels, ShouldResemble, map[string]string{"some-key": "some-val"})
 		})
 
 		Convey("Should return an error if AvroDatum didn't contain a goavro.Record", func() {

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -36,7 +36,7 @@ func nodeHandler(p *producerImpl) http.HandlerFunc {
 		}
 		if len(nodeMetrics) == 0 {
 			httpLog.Error("/v0/node - no content in store.")
-			http.Error(w, "No values found in store", http.StatusBadRequest)
+			http.Error(w, "No values found in store", http.StatusNoContent)
 			return
 		}
 

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -136,11 +136,10 @@ func containerAppMetricHandler(p *producerImpl) http.HandlerFunc {
 			producers.AppMetricPrefix, cid,
 		}, producers.MetricNamespaceSep)
 
-		appMetrics, ok := p.store.Get(key)
-		if !ok {
-			httpLog.Errorf("/v0/containers/{id}/app/{metric-id} - not found in store: %s", key)
-			http.Error(w, "Key not found in store", http.StatusNoContent)
-			return
+		appMetrics, err := p.store.GetByRegex(key + ".*" + mid)
+		if err != nil {
+			httpLog.Errorf("/v0/containers/{id}/app/{metric-id} - %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 
 		if _, ok := appMetrics.(producers.MetricsMessage); !ok {

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -111,16 +111,10 @@ func containerAppHandler(p *producerImpl) http.HandlerFunc {
 			return
 		}
 
-		var combinedMetrics producers.MetricsMessage
-		for _, c := range containerMetrics {
-			if _, ok := c.(producers.MetricsMessage); !ok {
-				httpLog.Errorf("/v0/containers/{id}/app - unsupported message type")
-				http.Error(w, "Got unsupported message type.", http.StatusInternalServerError)
-				return
-			}
-			metric := c.(producers.MetricsMessage)
-			combinedMetrics.Datapoints = append(combinedMetrics.Datapoints, metric.Datapoints...)
-			combinedMetrics.Dimensions = metric.Dimensions
+		combinedMetrics, err := combineMessages(containerMetrics)
+		if err != nil {
+			httpLog.Errorf("/v0/containers/{id}/app - %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		encode(combinedMetrics, w)
 	}

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -188,12 +188,13 @@ func encode(v interface{}, w http.ResponseWriter) {
 func combineMessages(mm map[string]interface{}) (producers.MetricsMessage, error) {
 	var combinedMetrics producers.MetricsMessage
 	for _, m := range mm {
-		if _, ok := m.(producers.MetricsMessage); !ok {
+		switch m := m.(type) {
+		case producers.MetricsMessage:
+			combinedMetrics.Datapoints = append(combinedMetrics.Datapoints, m.Datapoints...)
+			combinedMetrics.Dimensions = m.Dimensions
+		default:
 			return combinedMetrics, fmt.Errorf("Unsupported message type %v", m)
 		}
-		metric := m.(producers.MetricsMessage)
-		combinedMetrics.Datapoints = append(combinedMetrics.Datapoints, metric.Datapoints...)
-		combinedMetrics.Dimensions = metric.Dimensions
 	}
 	return combinedMetrics, nil
 }

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -31,7 +31,7 @@ func nodeHandler(p *producerImpl) http.HandlerFunc {
 		nodeMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(producers.NodeMetricPrefix) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/node - %s", err.Error())
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		if len(nodeMetrics) == 0 {
@@ -55,7 +55,7 @@ func containersHandler(p *producerImpl) http.HandlerFunc {
 		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(producers.ContainerMetricPrefix) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/containers - %s", err.Error())
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
@@ -117,7 +117,7 @@ func containerAppHandler(p *producerImpl) http.HandlerFunc {
 		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/containers/{id}/app - %s", err.Error())
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		if len(containerMetrics) == 0 {

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -89,9 +89,12 @@ func containerHandler(p *producerImpl) http.HandlerFunc {
 			return
 		}
 
-		httpLog.Debugf("Encoding container metrics:\n%+v", containerMetrics)
-
-		encode(containerMetrics, w)
+		combinedMetrics, err := combineMessages(containerMetrics)
+		if err != nil {
+			httpLog.Errorf("/v0/containers/{id} - %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		encode(combinedMetrics, w)
 	}
 }
 

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -181,4 +182,17 @@ func encode(v interface{}, w http.ResponseWriter) {
 		httpLog.Errorf("Failed to encode value to JSON: %v", v)
 		http.Error(w, "Failed to encode value to JSON", http.StatusInternalServerError)
 	}
+}
+
+func combineMessages(mm map[string]interface{}) (producers.MetricsMessage, error) {
+	var combinedMetrics producers.MetricsMessage
+	for _, m := range mm {
+		if _, ok := m.(producers.MetricsMessage); !ok {
+			return combinedMetrics, fmt.Errorf("Unsupported message type %v", m)
+		}
+		metric := m.(producers.MetricsMessage)
+		combinedMetrics.Datapoints = append(combinedMetrics.Datapoints, metric.Datapoints...)
+		combinedMetrics.Dimensions = metric.Dimensions
+	}
+	return combinedMetrics, nil
 }

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -78,8 +78,12 @@ func containerHandler(p *producerImpl) http.HandlerFunc {
 			producers.ContainerMetricPrefix, vars["id"],
 		}, producers.MetricNamespaceSep)
 
-		containerMetrics, ok := p.store.Get(key)
-		if !ok {
+		containerMetrics, err := p.store.GetByRegex(key + ".*")
+		if err != nil {
+			httpLog.Errorf("/v0/containers/{id} - %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		if len(containerMetrics) == 0 {
 			httpLog.Errorf("/v0/containers/{id} - not found in store: %s", key)
 			http.Error(w, "Key not found in store", http.StatusNoContent)
 			return

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -39,8 +39,12 @@ func nodeHandler(p *producerImpl) http.HandlerFunc {
 			return
 		}
 
-		httpLog.Error("/v0/node - no content in store.")
-		http.Error(w, "No values found in store", http.StatusBadRequest)
+		combinedMetrics, err := combineMessages(nodeMetrics)
+		if err != nil {
+			httpLog.Errorf("/v0/node - %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		encode(combinedMetrics, w)
 	}
 }
 

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 
 func nodeHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		nodeMetrics, err := p.store.GetByRegex(producers.NodeMetricPrefix + ".*")
+		nodeMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(producers.NodeMetricPrefix) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/node - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -51,7 +52,7 @@ func nodeHandler(p *producerImpl) http.HandlerFunc {
 func containersHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cm := []string{}
-		containerMetrics, err := p.store.GetByRegex(producers.ContainerMetricPrefix + ".*")
+		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(producers.ContainerMetricPrefix) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/containers - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -83,7 +84,7 @@ func containerHandler(p *producerImpl) http.HandlerFunc {
 			producers.ContainerMetricPrefix, vars["id"],
 		}, producers.MetricNamespaceSep)
 
-		containerMetrics, err := p.store.GetByRegex(key + ".*")
+		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/containers/{id} - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -111,7 +112,7 @@ func containerAppHandler(p *producerImpl) http.HandlerFunc {
 			producers.AppMetricPrefix, cid,
 		}, producers.MetricNamespaceSep)
 
-		containerMetrics, err := p.store.GetByRegex(key + ".*")
+		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/containers/{id}/app - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -141,7 +142,7 @@ func containerAppMetricHandler(p *producerImpl) http.HandlerFunc {
 			producers.AppMetricPrefix, cid,
 		}, producers.MetricNamespaceSep)
 
-		appMetrics, err := p.store.GetByRegex(key + ".*" + mid)
+		appMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*" + regexp.QuoteMeta(mid))
 		if err != nil {
 			httpLog.Errorf("/v0/containers/{id}/app/{metric-id} - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -148,18 +148,13 @@ func containerAppMetricHandler(p *producerImpl) http.HandlerFunc {
 			return
 		}
 
-		for _, dp := range appMetrics.(producers.MetricsMessage).Datapoints {
-			if dp.Name == mid {
-				m := producers.MetricsMessage{
-					Datapoints: []producers.Datapoint{dp},
-					Dimensions: appMetrics.(producers.MetricsMessage).Dimensions,
-				}
-				encode(m, w)
-				return
-			}
+		combinedMetrics, err := combineMessages(appMetrics)
+		if err != nil {
+			httpLog.Errorf("/v0/containers/{id}/app/{metric-id} - %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-		httpLog.Errorf("/v0/containers/{id}/app/{metric-id} - not found in store, CID: %s / Metric-ID: %s", key, mid)
-		http.Error(w, "Metric not found in store", http.StatusNoContent)
+
+		encode(combinedMetrics, w)
 	}
 }
 

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -142,9 +142,9 @@ func containerAppMetricHandler(p *producerImpl) http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 
-		if _, ok := appMetrics.(producers.MetricsMessage); !ok {
-			httpLog.Errorf("/v0/contianers - unsupported message type.")
-			http.Error(w, "Got unsupported message type.", http.StatusInternalServerError)
+		if len(appMetrics) == 0 {
+			httpLog.Errorf("/v0/containers/{id}/app/{metric-id} - not found in store, CID: %s / Metric-ID: %s", key, mid)
+			http.Error(w, "Key not found in store", http.StatusNoContent)
 			return
 		}
 

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -27,19 +27,15 @@ import (
 
 func nodeHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var am []interface{}
 		nodeMetrics, err := p.store.GetByRegex(producers.NodeMetricPrefix + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/node - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		for _, v := range nodeMetrics {
-			am = append(am, v)
-		}
-
-		if len(am) != 0 {
-			encode(am[0], w)
+		if len(nodeMetrics) == 0 {
+			httpLog.Error("/v0/node - no content in store.")
+			http.Error(w, "No values found in store", http.StatusBadRequest)
 			return
 		}
 

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/dcos/dcos-metrics/producers"
@@ -82,9 +81,7 @@ func containersHandler(p *producerImpl) http.HandlerFunc {
 func containerHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
-		key := strings.Join([]string{
-			producers.ContainerMetricPrefix, vars["id"],
-		}, producers.MetricNamespaceSep)
+		key := joinMetricName(producers.ContainerMetricPrefix, vars["id"])
 
 		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*")
 		if err != nil {
@@ -110,9 +107,7 @@ func containerAppHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		cid := vars["id"]
-		key := strings.Join([]string{
-			producers.AppMetricPrefix, cid,
-		}, producers.MetricNamespaceSep)
+		key := joinMetricName(producers.AppMetricPrefix, cid)
 
 		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*")
 		if err != nil {
@@ -140,9 +135,7 @@ func containerAppMetricHandler(p *producerImpl) http.HandlerFunc {
 		vars := mux.Vars(r)
 		cid := vars["id"]
 		mid := vars["metric-id"]
-		key := strings.Join([]string{
-			producers.AppMetricPrefix, cid, mid,
-		}, producers.MetricNamespaceSep)
+		key := joinMetricName(producers.AppMetricPrefix, cid, mid)
 
 		appMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*")
 		if err != nil {

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -58,13 +58,18 @@ func containersHandler(p *producerImpl) http.HandlerFunc {
 			return
 		}
 
+		// There will be multiple messages per container ID
+		uniqueIDs := make(map[string]bool)
 		for _, c := range containerMetrics {
 			if _, ok := c.(producers.MetricsMessage); !ok {
 				httpLog.Errorf("/v0/containers - unsupported message type")
 				http.Error(w, "Got unsupported message type.", http.StatusInternalServerError)
 				return
 			}
-			cm = append(cm, c.(producers.MetricsMessage).Dimensions.ContainerID)
+			uniqueIDs[c.(producers.MetricsMessage).Dimensions.ContainerID] = true
+		}
+		for id := range uniqueIDs {
+			cm = append(cm, id)
 		}
 
 		encode(cm, w)

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -141,10 +141,10 @@ func containerAppMetricHandler(p *producerImpl) http.HandlerFunc {
 		cid := vars["id"]
 		mid := vars["metric-id"]
 		key := strings.Join([]string{
-			producers.AppMetricPrefix, cid,
+			producers.AppMetricPrefix, cid, mid,
 		}, producers.MetricNamespaceSep)
 
-		appMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*" + regexp.QuoteMeta(mid))
+		appMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(key) + ".*")
 		if err != nil {
 			httpLog.Errorf("/v0/containers/{id}/app/{metric-id} - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -62,12 +62,14 @@ func containersHandler(p *producerImpl) http.HandlerFunc {
 		// There will be multiple messages per container ID
 		uniqueIDs := make(map[string]bool)
 		for _, c := range containerMetrics {
-			if _, ok := c.(producers.MetricsMessage); !ok {
+			switch c := c.(type) {
+			case producers.MetricsMessage:
+				uniqueIDs[c.Dimensions.ContainerID] = true
+			default:
 				httpLog.Errorf("/v0/containers - unsupported message type")
 				http.Error(w, "Got unsupported message type.", http.StatusInternalServerError)
 				return
 			}
-			uniqueIDs[c.(producers.MetricsMessage).Dimensions.ContainerID] = true
 		}
 		for id := range uniqueIDs {
 			cm = append(cm, id)

--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -92,6 +92,7 @@ func (p *producerImpl) Run() error {
 				name = strings.Join([]string{
 					message.Name,
 					message.Dimensions.ContainerID,
+					message.Datapoints[0].Name,
 				}, producers.MetricNamespaceSep)
 			}
 			httpLog.Debugf("Setting store object '%s' with timestamp %s",

--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -117,8 +117,9 @@ func (p *producerImpl) writeObjectToStore(d producers.Datapoint, m producers.Met
 	// e.g. dcos.metrics.app.[ContainerId].kafka.server.ReplicaFetcherManager.MaxLag
 	qualifiedName := joinMetricName(prefix, d.Name)
 	for k, v := range d.Tags {
-		// e.g. dcos.metrics.node.[MesosId].network.out.errors.interface.eth0
-		qualifiedName = joinMetricName(qualifiedName, k, v)
+		// e.g. dcos.metrics.node.[MesosId].network.out.errors.#interface:eth0
+		serializedTag := fmt.Sprintf("#%s:%s", k, v)
+		qualifiedName = joinMetricName(qualifiedName, serializedTag)
 	}
 	httpLog.Debugf("Setting store object '%s' with timestamp %s",
 		qualifiedName, time.Unix(newMessage.Timestamp, 0).Format(time.RFC3339))

--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -126,6 +126,10 @@ func (p *producerImpl) writeObjectToStore(d producers.Datapoint, m producers.Met
 	}
 	// e.g. dcos.metrics.app.kafka.server.ReplicaFetcherManager.MaxLag
 	qualifiedName := prefix + producers.MetricNamespaceSep + d.Name
+	for k, v := range d.Tags {
+		// e.g. dcos.metrics.node.network.out.errors.interface.eth0
+		qualifiedName = qualifiedName + producers.MetricNamespaceSep + k + producers.MetricNamespaceSep + v
+	}
 	httpLog.Debugf("Setting store object '%s' with timestamp %s",
 		qualifiedName, time.Unix(newMessage.Timestamp, 0).Format(time.RFC3339))
 	p.store.Set(qualifiedName, newMessage)

--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -114,10 +114,10 @@ func (p *producerImpl) writeObjectToStore(d producers.Datapoint, m producers.Met
 		Dimensions: m.Dimensions,
 		Timestamp:  m.Timestamp,
 	}
-	// e.g. dcos.metrics.app.kafka.server.ReplicaFetcherManager.MaxLag
+	// e.g. dcos.metrics.app.[ContainerId].kafka.server.ReplicaFetcherManager.MaxLag
 	qualifiedName := joinMetricName(prefix, d.Name)
 	for k, v := range d.Tags {
-		// e.g. dcos.metrics.node.network.out.errors.interface.eth0
+		// e.g. dcos.metrics.node.[MesosId].network.out.errors.interface.eth0
 		qualifiedName = joinMetricName(qualifiedName, k, v)
 	}
 	httpLog.Debugf("Setting store object '%s' with timestamp %s",

--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -92,7 +92,6 @@ func (p *producerImpl) Run() error {
 				name = strings.Join([]string{
 					message.Name,
 					message.Dimensions.ContainerID,
-					message.Datapoints[0].Name,
 				}, producers.MetricNamespaceSep)
 			}
 			httpLog.Debugf("Setting store object '%s' with timestamp %s",

--- a/producers/http/http_test.go
+++ b/producers/http/http_test.go
@@ -57,9 +57,15 @@ func TestRun(t *testing.T) {
 			go p.Run()
 			time.Sleep(1 * time.Second)
 
+			dps := []producers.Datapoint{
+				producers.Datapoint{
+					Name: "datapoint-one",
+				},
+			}
 			p.metricsChan <- producers.MetricsMessage{
-				Name:      "some-message",
-				Timestamp: time.Now().UTC().Unix(),
+				Name:       "some-message",
+				Datapoints: dps,
+				Timestamp:  time.Now().UTC().Unix(),
 			}
 			time.Sleep(250 * time.Millisecond)
 

--- a/producers/http/http_test.go
+++ b/producers/http/http_test.go
@@ -72,6 +72,51 @@ func TestRun(t *testing.T) {
 			So(p.store.Size(), ShouldEqual, 1)
 		})
 
+		Convey("Shoud not overwrite metrics delivered in sequence", func() {
+			port, err := getEphemeralPort()
+			if err != nil {
+				panic(err)
+			}
+
+			p := producerImpl{
+				config:             Config{Port: port},
+				store:              store.New(),
+				metricsChan:        make(chan producers.MetricsMessage),
+				janitorRunInterval: 60 * time.Second,
+			}
+			go p.Run()
+			time.Sleep(1 * time.Second)
+
+			dp1 := []producers.Datapoint{
+				producers.Datapoint{Name: "datapoint-one"},
+			}
+			dp2 := []producers.Datapoint{
+				producers.Datapoint{Name: "datapoint-two"},
+			}
+
+			// Datapoint one is written
+			p.metricsChan <- producers.MetricsMessage{
+				Name:       "some-message",
+				Datapoints: dp1,
+				Timestamp:  time.Now().UTC().Unix(),
+			}
+			// Datapoint two is written
+			p.metricsChan <- producers.MetricsMessage{
+				Name:       "some-message",
+				Datapoints: dp2,
+				Timestamp:  time.Now().UTC().Unix(),
+			}
+			// Datapoint one is _overwritten_
+			p.metricsChan <- producers.MetricsMessage{
+				Name:       "some-message",
+				Datapoints: dp1,
+				Timestamp:  time.Now().UTC().Unix(),
+			}
+			time.Sleep(250 * time.Millisecond)
+
+			So(p.store.Size(), ShouldEqual, 2)
+		})
+
 		Convey("Should create a new router on a systemd socket (if it's available)", func() {
 			// Mock the systemd socket
 			if err := os.Setenv("LISTEN_PID", strconv.Itoa(os.Getpid())); err != nil {


### PR DESCRIPTION
The design of the metrics collector expected batched statsd input. When input was received, it was given a name constructed from the type of input plus the container ID, for example `dcos.metrics.app.ba5598ef-9cb7-47a1-8f37-1a7e8bf09e84`. This was stored in memory and retrieved by name when the user hit the appropriate endpoint (in this case `/metrics/v0/containers/ba5598ef-9cb7-47a1-8f37-1a7e8bf09e84/app`)

Unfortunately, most applications which use statsd don't batch their inputs, but emit them one-by-one or in chunks, as is convenient. This was causing distinct metrics to be overwritten repeatedly, since they shared the same ID. When the user hit the endpoint, only the most recent received datum or data was served. 

This PR inserts each incoming datapoint into the store using a fully qualified name made up of the input type and container ID as before, but also the name of the datapoint, eg `dcos.metrics.app.ba5598ef-9cb7-47a1-8f37-1a7e8bf09e84.kafka.network.RequestMetrics.LocalTimeMs.min`. The datapoints are combined when the user hits the appropriate endpoint. 