### PR TITLE
Scrape app metrics in plugins

### DIFF
--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -235,7 +235,7 @@ func (p *Plugin) setEndpoints() error {
 		for _, c := range containers {
 			e := "/system/v1/metrics/v0/containers/" + c
 			p.Log.Infof("Discovered new container endpoint %s", e)
-			p.Endpoints = append(p.Endpoints, e)
+			p.Endpoints = append(p.Endpoints, e, e+"/app")
 		}
 
 		return nil

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -263,6 +263,12 @@ func makeMetricsRequest(client *http.Client, request *http.Request) (producers.M
 		return mm, err
 	}
 
+	// 204 No Content is not an error code; we handle it explicitly
+	if resp.StatusCode == http.StatusNoContent {
+		l.Warnf("Empty response received from endpoint: %+v", request.URL)
+		return mm, nil
+	}
+
 	err = json.Unmarshal(body, &mm)
 	if err != nil {
 		l.Errorf("Encountered error parsing JSON, %s. JSON Content was: %s", err.Error(), body)


### PR DESCRIPTION
Due to an oversight, plugins only ever hit the /node and /container/<container-id> endpoints. 

This PR ensures that they also hit the `/container/<container-id>/app` endpoint. It also deals with the possibility of 204 No Content responses, which are common on `/app` endpoints where the app is newly started. 