### PR TITLE
Allow statsd envvars to propagate to tasks running on the default executor

### DIFF
--- a/mesos_module/isolator_module.cpp
+++ b/mesos_module/isolator_module.cpp
@@ -37,6 +37,10 @@ namespace metrics {
       : container_assigner(container_assigner) { }
     virtual ~IsolatorProcess() { }
 
+    bool supportsNesting() {
+      return true;
+    }
+
     process::Future<Nothing> recover(
         const std::list<mesos::slave::ContainerState>& states,
         const hashset<mesos::ContainerID>& orphans) {


### PR DESCRIPTION
The `STATSD_UDP_HOST` and `STATSD_UDP_PORT` envvars are usually set by the dcos-metrics module for the sake of services running on DC/OS, but the module doesn't currently support the task group structure exposed by the default executor, meaning that those variables will not be exposed in that case. This change allows access to those envvars for tasks running on top of the default executor.