### PR TITLE
Sort tags

### DIFF
--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -117,7 +117,8 @@ func (p *producerImpl) writeObjectToStore(d producers.Datapoint, m producers.Met
 	}
 	// e.g. dcos.metrics.app.[ContainerId].kafka.server.ReplicaFetcherManager.MaxLag
 	qualifiedName := joinMetricName(prefix, d.Name)
-	for k, v := range d.Tags {
+	for _, pair := range sortTags(d.Tags) {
+		k, v := pair[0], pair[1]
 		// e.g. dcos.metrics.node.[MesosId].network.out.errors.#interface:eth0
 		serializedTag := fmt.Sprintf("#%s:%s", k, v)
 		qualifiedName = joinMetricName(qualifiedName, serializedTag)

--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -124,6 +125,22 @@ func (p *producerImpl) writeObjectToStore(d producers.Datapoint, m producers.Met
 	httpLog.Debugf("Setting store object '%s' with timestamp %s",
 		qualifiedName, time.Unix(newMessage.Timestamp, 0).Format(time.RFC3339))
 	p.store.Set(qualifiedName, newMessage)
+}
+
+// sortTags turns a map[string]string into a slice of key/values, sorted by key.
+func sortTags(tags map[string]string) [][]string {
+	keys := make([]string, len(tags))
+	result := make([][]string, len(tags))
+	i := 0
+	for k := range tags {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		result[i] = []string{k, tags[k]}
+	}
+	return result
 }
 
 // joinMetricName concatenates its arguments using the metric name separator

--- a/producers/http/http_test.go
+++ b/producers/http/http_test.go
@@ -228,3 +228,24 @@ func TestJanitor(t *testing.T) {
 		})
 	})
 }
+
+func TestSortTags(t *testing.T) {
+	Convey("When sorting tags", t, func() {
+		someTags := map[string]string{
+			"foo":   "bar",
+			"baz":   "qux",
+			"corge": "grault",
+		}
+		sortedTags := sortTags(someTags)
+
+		Convey("all keys should be returned as a pair", func() {
+			So(len(sortedTags), ShouldEqual, 3)
+		})
+
+		Convey("tags should be sorted by key", func() {
+			So(sortedTags[0], ShouldResemble, []string{"baz", "qux"})
+			So(sortedTags[1], ShouldResemble, []string{"corge", "grault"})
+			So(sortedTags[2], ShouldResemble, []string{"foo", "bar"})
+		})
+	})
+}


### PR DESCRIPTION
_Fixes https://jira.mesosphere.com/browse/DCOS_OSS-1451_
___
This PR ensures that when a datapoint is set in the store, its tags are sorted first. Before this change, tags were added to a datapoint's key by iterating over a map; however, since map iteration in golang is intentionally randomised, two datapoints with identical names and identical tags could end up with different store keys. 

This resulted in multiple datapoints being shown in some circumstances. It disproportionately affected the `/containers/container-id` endpoint since the datapoints there have multiple tags. A sample output showing stale data:
https://gist.github.com/minyk/826e1856a5638e6ccf51d0fcb32c998a