### PR TITLE
Fix crash when container statistics are not available

### DIFF
--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -102,9 +102,14 @@ func (c *Collector) metricsMessages() (out []producers.MetricsMessage) {
 	t := time.Unix(c.timestamp, 0)
 
 	for _, cm := range c.containerMetrics {
+		datapoints, err := c.createContainerDatapoints(cm)
+		if err != nil {
+			c.log.Warnf("Could not create datapoints for container ID %s: %s", cm.ContainerID, err)
+			continue
+		}
 		msg = producers.MetricsMessage{
 			Name:       producers.ContainerMetricPrefix,
-			Datapoints: c.createContainerDatapoints(cm),
+			Datapoints: datapoints,
 			Timestamp:  t.UTC().Unix(),
 		}
 

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -103,8 +103,8 @@ func (c *Collector) metricsMessages() (out []producers.MetricsMessage) {
 
 	for _, cm := range c.containerMetrics {
 		datapoints, err := c.createContainerDatapoints(cm)
-		if err != nil {
-			c.log.Warnf("Could not create datapoints for container ID %s: %s", cm.ContainerID, err)
+		if err == ErrNoStatistics {
+			c.log.Warnf("Container ID %q did not supply any statistics; no metrics message will be sent", cm.ContainerID)
 			continue
 		}
 		msg = producers.MetricsMessage{

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -107,6 +107,10 @@ func (c *Collector) metricsMessages() (out []producers.MetricsMessage) {
 			c.log.Warnf("Container ID %q did not supply any statistics; no metrics message will be sent", cm.ContainerID)
 			continue
 		}
+		if err != nil {
+			c.log.Errorf("Could not retrieve datapoints for container ID %q: %s", cm.ContainerID, err)
+			continue
+		}
 		msg = producers.MetricsMessage{
 			Name:       producers.ContainerMetricPrefix,
 			Datapoints: datapoints,

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -144,6 +144,36 @@ var (
 				}
 			}
 		]`)
+
+	deficientContainerMetrics = []byte(`
+		[
+			{
+				"container_id": "e4faacb2-f69f-4ea1-9d96-eb06fea75eef",
+				"executor_id": "foo.adf2b6f4-a171-11e6-9182-080027fb5b88",
+				"executor_name": "Command Executor (Task: foo.adf2b6f4-a171-11e6-9182-080027fb5b88) (Command: sh -c 'sleep 900')",
+				"framework_id": "5349f49b-68b3-4638-aab2-fc4ec845f993-0000",
+				"source": "foo.adf2b6f4-a171-11e6-9182-080027fb5b88",
+				"statistics": {
+					"cpus_limit": 1.1,
+					"cpus_system_time_secs": 0.31,
+					"cpus_user_time_secs": 0.22,
+					"mem_limit_bytes": 167772160,
+					"mem_total_bytes": 4476928
+				}
+			},
+			{
+				"container_id": "623cd286-0b5e-4d1b-895b-8ca30d1fbe05",
+				"executor_id": "boba_20170731215525xd01p.87bf554a-763f-11e7-90b8-70b3d5800001",
+				"executor_name": "Command Executor (Task: boba_20170731215525xd01p.87bf554a-763f-11e7-90b8-70b3d5800001) (Command: sh -c 'sleep 1')",
+				"framework_id": "378ac077-d22b-445f-8f6e-942956eb5ee4-0000",
+				"source": "boba_20170731215525xd01p.87bf554a-763f-11e7-90b8-70b3d5800001",
+				"status": {
+						"container_id": {
+						"value": "623cd286-0b5e-4d1b-895b-8ca30d1fbe05"
+					}
+				}
+			}
+		]`)
 )
 
 func TestGetContainerMetrics(t *testing.T) {
@@ -318,7 +348,7 @@ func TestTransform(t *testing.T) {
 		if err := json.Unmarshal(mockAgentState, &mac.agentState); err != nil {
 			panic(err)
 		}
-		if err := json.Unmarshal(mockContainerMetrics, &mac.containerMetrics); err != nil {
+		if err := json.Unmarshal(deficientContainerMetrics, &mac.containerMetrics); err != nil {
 			panic(err)
 		}
 

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -303,7 +303,7 @@ func TestBuildDatapoints(t *testing.T) {
 				}
 
 				for _, container := range thisContainerMetrics {
-					result := coll.createContainerDatapoints(container)
+					result, _ := coll.createContainerDatapoints(container)
 					So(len(result), ShouldEqual, 16)
 
 					cidRegistry := []string{}

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -303,7 +303,8 @@ func TestBuildDatapoints(t *testing.T) {
 				}
 
 				for _, container := range thisContainerMetrics {
-					result, _ := coll.createContainerDatapoints(container)
+					result, err := coll.createContainerDatapoints(container)
+					So(err, ShouldEqual, nil)
 					So(len(result), ShouldEqual, 16)
 
 					cidRegistry := []string{}

--- a/collectors/mesos/agent/metrics.go
+++ b/collectors/mesos/agent/metrics.go
@@ -15,6 +15,7 @@
 package agent
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/dcos/dcos-metrics/producers"
@@ -35,7 +36,7 @@ const (
 	bytes   = "bytes"
 )
 
-func (c *Collector) createContainerDatapoints(container agentContainer) []producers.Datapoint {
+func (c *Collector) createContainerDatapoints(container agentContainer) ([]producers.Datapoint, error) {
 	ts := thisTime()
 	dps := []producers.Datapoint{}
 
@@ -48,6 +49,11 @@ func (c *Collector) createContainerDatapoints(container agentContainer) []produc
 	}
 
 	c.log.Debugf("Adding tags for container %s:\n%+v", container.ContainerID, dpTags)
+
+	// It's possible for statistics to be missing
+	if container.Statistics == nil {
+		return dps, fmt.Errorf("Container %s supplied no statistics", container.ContainerID)
+	}
 
 	addDps := []producers.Datapoint{
 		producers.Datapoint{
@@ -153,7 +159,7 @@ func (c *Collector) createContainerDatapoints(container agentContainer) []produc
 		dps = append(dps, dp)
 	}
 
-	return dps
+	return dps, nil
 }
 
 // -- helpers


### PR DESCRIPTION
The mesos `/containers` endpoint returns an array of containers, [as documented here](http://mesos.apache.org/documentation/latest/endpoints/slave/containers/).

It's possible (although undesirable and, arguably, wrong) for the `statistics` member of the container object to be missing, especially in recently-launched jobs. Unfortunately the mesos collector did not guard against this, and when encountering such a circumstance the whole dcos-metrics-agent process could segfault and crash.

Users who make heavy use of frameworks like Chronos and Metronome could see metrics crash occasionally as a result. 

This PR adds a guard for such cases; container members without statistics will result in a warning and no metrics message for the affected container is sent. 