### PR TITLE
Fall back to HTTP on mesos state fetch error

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -115,13 +116,18 @@ func (c *Config) getNodeInfo(attemptSSL bool) error {
 	}
 
 	// If there is no available certificate, immediately drop back to HTTP
-	var useSSL = attemptSSL && len(c.IAMConfigPath) > 0
+	useSSL := attemptSSL && len(c.IAMConfigPath) > 0
 	// Create a new DC/OS nodeutil instance
-	var stateURL = "http://leader.mesos:5050/state"
-	if useSSL {
-		stateURL = "https://leader.mesos:5050/state"
+	stateURL := url.URL{
+		Scheme: "http",
+		Host:   "leader.mesos:5050",
+		Path:   "/state",
 	}
-	node, err := nodeutil.NewNodeInfo(client, c.DCOSRole, nodeutil.OptionMesosStateURL(stateURL))
+	if useSSL {
+		stateURL.Scheme = "https"
+	}
+
+	node, err := nodeutil.NewNodeInfo(client, c.DCOSRole, nodeutil.OptionMesosStateURL(stateURL.String()))
 	if err != nil {
 		return fmt.Errorf("error: could not get nodeInfo: %s", err)
 	}

--- a/config.go
+++ b/config.go
@@ -117,7 +117,6 @@ func (c *Config) getNodeInfo(attemptSSL bool) error {
 
 	// If there is no available certificate, immediately drop back to HTTP
 	useSSL := attemptSSL && len(c.IAMConfigPath) > 0
-	// Create a new DC/OS nodeutil instance
 	stateURL := url.URL{
 		Scheme: "http",
 		Host:   "leader.mesos:5050",
@@ -127,6 +126,7 @@ func (c *Config) getNodeInfo(attemptSSL bool) error {
 		stateURL.Scheme = "https"
 	}
 
+	// Create a new DC/OS nodeutil instance
 	node, err := nodeutil.NewNodeInfo(client, c.DCOSRole, nodeutil.OptionMesosStateURL(stateURL.String()))
 	if err != nil {
 		return fmt.Errorf("error: could not get nodeInfo: %s", err)


### PR DESCRIPTION
At present, dcos-metrics will poll using https whenever an IAM option is supplied in its config parameters. Otherwise it will use HTTP. This is normally fine, because Mesos will serve a 307 redirect to HTTP when the SSL_DOWNGRADE is enabled, and dcos-metrics respects the redirect, 

However, it's possible for Mesos to get itself into a state where the SSL handshake fails. In this case, metrics crashes with the message "Get https://leader.mesos:5050/state: EOF". 

In this PR we introduce a fallback - if any error occurs during an attempt to get state with HTTPS, we fall back to HTTP instead. 

ping @amitaekbote 