### PR TITLE
Add task ID to /container endpoint

### DIFF
--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -165,7 +165,7 @@ func getFrameworkInfoByFrameworkID(frameworkID string, frameworks []frameworkInf
 	return frameworkInfo{}, false
 }
 
-// getExecutorInfoByExecutorID returns the ExecutorInfo struct given its ID.
+// getExecutorInfoByExecutorID returns the executorInfo struct given its ID.
 func getExecutorInfoByExecutorID(executorID string, executors []executorInfo) (executorInfo, bool) {
 	for _, executor := range executors {
 		if executor.ID == executorID {

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -150,6 +150,16 @@ func getFrameworkInfoByFrameworkID(frameworkID string, frameworks []frameworkInf
 	return frameworkInfo{}, false
 }
 
+// getExecutorInfoByExecutorID returns the ExecutorInfo struct given its ID.
+func getExecutorInfoByExecutorID(executorID string, executors []executorInfo) (executorInfo, bool) {
+	for _, executor := range executors {
+		if executor.ID == executorID {
+			return executor, true
+		}
+	}
+	return executorInfo{}, false
+}
+
 // getLabelsByContainerID returns a map of labels, as specified by the framework
 // that created the executor. In the case of Marathon, the framework allows the
 // user to specify their own arbitrary labels per application.

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -160,6 +160,16 @@ func getExecutorInfoByExecutorID(executorID string, executors []executorInfo) (e
 	return executorInfo{}, false
 }
 
+// getTaskInfoByContainerID returns the TaskInfo struct matching the given cID.
+func getTaskInfoByContainerID(containerID string, tasks []taskInfo) (taskInfo, bool) {
+	for _, task := range tasks {
+		if len(task.Statuses) > 0 && task.Statuses[0].ContainerStatusInfo.ID.Value == containerID {
+			return task, true
+		}
+	}
+	return taskInfo{}, false
+}
+
 // getLabelsByContainerID returns a map of labels, as specified by the framework
 // that created the executor. In the case of Marathon, the framework allows the
 // user to specify their own arbitrary labels per application.

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -64,6 +64,16 @@ var (
 											"key": "somekey",
 											"value": "someval"
 										}
+									],
+									"statuses": [
+										{
+											"state": "TASK_RUNNING",
+											"container_status": {
+												"container_id": {
+													"value": "e4faacb2-f69f-4ea1-9d96-eb06fea75eef"
+												}
+											}
+										}
 									]
 								}
 							]

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -420,6 +420,11 @@ func TestGetTaskInfoByContainerID(t *testing.T) {
 	Convey("When getting a task's info, given a container ID", t, func() {
 		ti := []taskInfo{
 			taskInfo{
+				Name:     "should-not-error",
+				ID:       "should-not-error.123",
+				Statuses: []taskStatusInfo{},
+			},
+			taskInfo{
 				Name: "foo",
 				ID:   "foo.123",
 				Statuses: []taskStatusInfo{

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -131,7 +131,7 @@ var (
 		[
 			{
 				"container_id": "e4faacb2-f69f-4ea1-9d96-eb06fea75eef",
-				"executor_id": "foo.adf2b6f4-a171-11e6-9182-080027fb5b88",
+				"executor_id": "foo.124b1048-a17a-11e6-9182-080027fb5b88",
 				"executor_name": "Command Executor (Task: foo.adf2b6f4-a171-11e6-9182-080027fb5b88) (Command: sh -c 'sleep 900')",
 				"framework_id": "5349f49b-68b3-4638-aab2-fc4ec845f993-0000",
 				"source": "foo.adf2b6f4-a171-11e6-9182-080027fb5b88",
@@ -149,7 +149,7 @@ var (
 		[
 			{
 				"container_id": "e4faacb2-f69f-4ea1-9d96-eb06fea75eef",
-				"executor_id": "foo.adf2b6f4-a171-11e6-9182-080027fb5b88",
+				"executor_id": "foo.124b1048-a17a-11e6-9182-080027fb5b88",
 				"executor_name": "Command Executor (Task: foo.adf2b6f4-a171-11e6-9182-080027fb5b88) (Command: sh -c 'sleep 900')",
 				"framework_id": "5349f49b-68b3-4638-aab2-fc4ec845f993-0000",
 				"source": "foo.adf2b6f4-a171-11e6-9182-080027fb5b88",

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -484,8 +484,8 @@ func TestGetLabelsByContainerID(t *testing.T) {
 				Executors: []executorInfo{
 					executorInfo{
 						Container: "someContainerID",
-						Labels: []stateLabel{
-							stateLabel{
+						Labels: []keyValue{
+							keyValue{
 								Key:   "somekey",
 								Value: "someval",
 							},
@@ -493,12 +493,12 @@ func TestGetLabelsByContainerID(t *testing.T) {
 					},
 					executorInfo{
 						Container: "containerWithLongLabelID",
-						Labels: []stateLabel{
-							stateLabel{
+						Labels: []keyValue{
+							keyValue{
 								Key:   "somekey",
 								Value: "someval",
 							},
-							stateLabel{
+							keyValue{
 								Key:   "longkey",
 								Value: "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
 							},

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -399,18 +399,17 @@ func TestGetFrameworkInfoByFrameworkID(t *testing.T) {
 		}
 
 		Convey("Should return the framework name without errors", func() {
-			result, ok := getFrameworkInfoByFrameworkID("7", fi)
-			So(ok, ShouldBeTrue)
+			result := getFrameworkInfoByFrameworkID("7", fi)
+			So(result, ShouldNotBeNil)
 			So(result.Name, ShouldEqual, "fooframework")
 			So(result.ID, ShouldEqual, "7")
 			So(result.Role, ShouldEqual, "foorole")
 			So(result.Principal, ShouldEqual, "fooprincipal")
 		})
 
-		Convey("Should return an empty frameworkInfo if no match was found", func() {
-			result, ok := getFrameworkInfoByFrameworkID("42", fi)
-			So(result, ShouldResemble, frameworkInfo{})
-			So(ok, ShouldBeFalse)
+		Convey("Should return nil if no match was found", func() {
+			result := getFrameworkInfoByFrameworkID("42", fi)
+			So(result, ShouldBeNil)
 		})
 	})
 }
@@ -425,15 +424,14 @@ func TestGetExecutorInfoByExecutorID(t *testing.T) {
 			},
 		}
 		Convey("Should return the executor's info, given an executor ID", func() {
-			result, ok := getExecutorInfoByExecutorID("pierrepoint.1234", ei)
-			So(ok, ShouldBeTrue)
+			result := getExecutorInfoByExecutorID("pierrepoint.1234", ei)
+			So(result, ShouldNotBeNil)
 			So(result.ID, ShouldEqual, "pierrepoint.1234")
 			So(result.Name, ShouldEqual, "pierrepoint")
 		})
 		Convey("Should return an empty executorInfo if no match was found", func() {
-			result, ok := getExecutorInfoByExecutorID("not-an-executor-id", ei)
-			So(ok, ShouldBeFalse)
-			So(result, ShouldResemble, executorInfo{})
+			result := getExecutorInfoByExecutorID("not-an-executor-id", ei)
+			So(result, ShouldBeNil)
 		})
 	})
 }
@@ -461,15 +459,14 @@ func TestGetTaskInfoByContainerID(t *testing.T) {
 			},
 		}
 		Convey("Should return the relevant task info without errors", func() {
-			result, ok := getTaskInfoByContainerID("e4faacb2-f69f-4ea1-9d96-eb06fea75eef", ti)
-			So(ok, ShouldBeTrue)
+			result := getTaskInfoByContainerID("e4faacb2-f69f-4ea1-9d96-eb06fea75eef", ti)
+			So(result, ShouldNotBeNil)
 			So(result.Name, ShouldEqual, "foo")
 			So(result.ID, ShouldEqual, "foo.123")
 		})
 		Convey("Should return an empty frameworkInfo if no match was found", func() {
-			result, ok := getTaskInfoByContainerID("not-a-real-container-id", ti)
-			So(ok, ShouldBeFalse)
-			So(result, ShouldResemble, taskInfo{})
+			result := getTaskInfoByContainerID("not-a-real-container-id", ti)
+			So(result, ShouldBeNil)
 		})
 	})
 }

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -393,6 +393,29 @@ func TestGetFrameworkInfoByFrameworkID(t *testing.T) {
 	})
 }
 
+func TestGetExecutorInfoByExecutorID(t *testing.T) {
+	Convey("When getting an executor's info, given its ID", t, func() {
+		ei := []executorInfo{
+			executorInfo{
+				Name:      "pierrepoint",
+				ID:        "pierrepoint.1234",
+				Container: "foo.container.1234556",
+			},
+		}
+		Convey("Should return the executor's info, given an executor ID", func() {
+			result, ok := getExecutorInfoByExecutorID("pierrepoint.1234", ei)
+			So(ok, ShouldBeTrue)
+			So(result.ID, ShouldEqual, "pierrepoint.1234")
+			So(result.Name, ShouldEqual, "pierrepoint")
+		})
+		Convey("Should return an empty executorInfo if no match was found", func() {
+			result, ok := getExecutorInfoByExecutorID("not-an-executor-id", ei)
+			So(ok, ShouldBeFalse)
+			So(result, ShouldResemble, executorInfo{})
+		})
+	})
+}
+
 func TestGetLabelsByContainerID(t *testing.T) {
 	tl := logrus.WithFields(logrus.Fields{"test": "this"})
 	Convey("When getting the labels for a container, given its ID", t, func() {

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -403,8 +403,8 @@ func TestGetLabelsByContainerID(t *testing.T) {
 				Executors: []executorInfo{
 					executorInfo{
 						Container: "someContainerID",
-						Labels: []executorLabels{
-							executorLabels{
+						Labels: []stateLabel{
+							stateLabel{
 								Key:   "somekey",
 								Value: "someval",
 							},
@@ -412,12 +412,12 @@ func TestGetLabelsByContainerID(t *testing.T) {
 					},
 					executorInfo{
 						Container: "containerWithLongLabelID",
-						Labels: []executorLabels{
-							executorLabels{
+						Labels: []stateLabel{
+							stateLabel{
 								Key:   "somekey",
 								Value: "someval",
 							},
-							executorLabels{
+							stateLabel{
 								Key:   "longkey",
 								Value: "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
 							},

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -416,6 +416,37 @@ func TestGetExecutorInfoByExecutorID(t *testing.T) {
 	})
 }
 
+func TestGetTaskInfoByContainerID(t *testing.T) {
+	Convey("When getting a task's info, given a container ID", t, func() {
+		ti := []taskInfo{
+			taskInfo{
+				Name: "foo",
+				ID:   "foo.123",
+				Statuses: []taskStatusInfo{
+					taskStatusInfo{
+						ContainerStatusInfo: containerStatusInfo{
+							ID: containerStatusID{
+								Value: "e4faacb2-f69f-4ea1-9d96-eb06fea75eef",
+							},
+						},
+					},
+				},
+			},
+		}
+		Convey("Should return the relevant task info without errors", func() {
+			result, ok := getTaskInfoByContainerID("e4faacb2-f69f-4ea1-9d96-eb06fea75eef", ti)
+			So(ok, ShouldBeTrue)
+			So(result.Name, ShouldEqual, "foo")
+			So(result.ID, ShouldEqual, "foo.123")
+		})
+		Convey("Should return an empty frameworkInfo if no match was found", func() {
+			result, ok := getTaskInfoByContainerID("not-a-real-container-id", ti)
+			So(ok, ShouldBeFalse)
+			So(result, ShouldResemble, taskInfo{})
+		})
+	})
+}
+
 func TestGetLabelsByContainerID(t *testing.T) {
 	tl := logrus.WithFields(logrus.Fields{"test": "this"})
 	Convey("When getting the labels for a container, given its ID", t, func() {

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -349,18 +349,27 @@ func TestTransform(t *testing.T) {
 		if err := json.Unmarshal(mockAgentState, &mac.agentState); err != nil {
 			panic(err)
 		}
-		if err := json.Unmarshal(deficientContainerMetrics, &mac.containerMetrics); err != nil {
-			panic(err)
-		}
-
-		Convey("Should return a []producers.MetricsMessage without errors", func() {
+		Convey("With container metrics", func() {
+			if err := json.Unmarshal(mockContainerMetrics, &mac.containerMetrics); err != nil {
+				panic(err)
+			}
 			result := mac.metricsMessages()
 			So(len(result), ShouldEqual, 1) // one container message
 
 			// From the implementation of a.transform() and the mocks in this test file,
 			// result[0] will be agent metrics, and result[1] will be container metrics.
-			So(result[0].Dimensions.FrameworkName, ShouldEqual, "marathon")
-			So(result[0].Dimensions.FrameworkPrincipal, ShouldEqual, "dcos_marathon")
+			Convey("Should return a []producers.MetricsMessage without errors", func() {
+				So(result[0].Dimensions.FrameworkName, ShouldEqual, "marathon")
+				So(result[0].Dimensions.FrameworkPrincipal, ShouldEqual, "dcos_marathon")
+			})
+		})
+
+		Convey("Missing container metrics", func() {
+			if err := json.Unmarshal(deficientContainerMetrics, &mac.containerMetrics); err != nil {
+				panic(err)
+			}
+			result := mac.metricsMessages()
+			So(len(result), ShouldEqual, 1) // one container message
 		})
 	})
 }

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -356,8 +356,6 @@ func TestTransform(t *testing.T) {
 			result := mac.metricsMessages()
 			So(len(result), ShouldEqual, 1) // one container message
 
-			// From the implementation of a.transform() and the mocks in this test file,
-			// result[0] will be agent metrics, and result[1] will be container metrics.
 			Convey("Should return a []producers.MetricsMessage without errors", func() {
 				So(result[0].Dimensions.FrameworkName, ShouldEqual, "marathon")
 				So(result[0].Dimensions.FrameworkPrincipal, ShouldEqual, "dcos_marathon")

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -370,6 +370,11 @@ func TestTransform(t *testing.T) {
 				So(result[0].Dimensions.FrameworkName, ShouldEqual, "marathon")
 				So(result[0].Dimensions.FrameworkPrincipal, ShouldEqual, "dcos_marathon")
 			})
+
+			Convey("Should return task ID and name with container metrics", func() {
+				So(result[0].Dimensions.TaskID, ShouldEqual, "foo.124b1048-a17a-11e6-9182-080027fb5b88")
+				So(result[0].Dimensions.TaskName, ShouldEqual, "foo")
+			})
 		})
 
 		Convey("Missing container metrics", func() {

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -35,6 +35,17 @@ import (
 //   * Framework info: https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L207-L307
 //   * Executor info:  https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L474-L522
 //
+// An important note on the difference between master and agent state:
+//
+// On the agent, both `frameworks` and `completed_frameworks` will list both
+// `executors` and `completed_executors`, which each may list `tasks`,
+// `queued_tasks` (not yet started), and `completed_tasks` (although
+// completed frameworks/executors should only list completed tasks). On the
+// master, both `frameworks` and `completed_frameworks` will list `tasks`,
+// `unreachable_tasks` (agent unreachable), and `completed_tasks`.
+// `orphan_tasks` are no longer possible as of Mesos 1.2.
+//
+
 type agentState struct {
 	ID         string          `json:"id"`
 	Hostname   string          `json:"hostname"`

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -54,10 +54,30 @@ type executorInfo struct {
 	Name      string           `json:"name"`
 	Container string           `json:"container"`
 	Labels    []executorLabels `json:"labels,omitempty"` // labels are optional
+	Tasks     []taskInfo       `json:"tasks,omitempty"`
 }
 
 type executorLabels struct {
 	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type taskInfo struct {
+	ID       string           `json:"id"`
+	Name     string           `json:"name"`
+	Labels   []executorLabels `json:"labels,omitempty"` // re-using executor labels for now
+	Statuses []taskStatusInfo `json:"statuses,omitempty"`
+}
+
+type taskStatusInfo struct {
+	ContainerStatusInfo containerStatusInfo `json:"container_status"`
+}
+
+type containerStatusInfo struct {
+	ID containerStatusID `json:"container_id"`
+}
+
+type containerStatusID struct {
 	Value string `json:"value"`
 }
 

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -50,14 +50,14 @@ type frameworkInfo struct {
 }
 
 type executorInfo struct {
-	ID        string           `json:"id"`
-	Name      string           `json:"name"`
-	Container string           `json:"container"`
-	Labels    []executorLabels `json:"labels,omitempty"` // labels are optional
-	Tasks     []taskInfo       `json:"tasks,omitempty"`
+	ID        string       `json:"id"`
+	Name      string       `json:"name"`
+	Container string       `json:"container"`
+	Labels    []stateLabel `json:"labels,omitempty"` // labels are optional
+	Tasks     []taskInfo   `json:"tasks,omitempty"`
 }
 
-type executorLabels struct {
+type stateLabel struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
@@ -65,7 +65,7 @@ type executorLabels struct {
 type taskInfo struct {
 	ID       string           `json:"id"`
 	Name     string           `json:"name"`
-	Labels   []executorLabels `json:"labels,omitempty"` // re-using executor labels for now
+	Labels   []stateLabel     `json:"labels,omitempty"`
 	Statuses []taskStatusInfo `json:"statuses,omitempty"`
 }
 

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -61,14 +61,14 @@ type frameworkInfo struct {
 }
 
 type executorInfo struct {
-	ID        string       `json:"id"`
-	Name      string       `json:"name"`
-	Container string       `json:"container"`
-	Labels    []stateLabel `json:"labels,omitempty"` // labels are optional
-	Tasks     []taskInfo   `json:"tasks,omitempty"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	Container string     `json:"container"`
+	Labels    []keyValue `json:"labels,omitempty"` // labels are optional
+	Tasks     []taskInfo `json:"tasks,omitempty"`
 }
 
-type stateLabel struct {
+type keyValue struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
@@ -76,7 +76,7 @@ type stateLabel struct {
 type taskInfo struct {
 	ID       string           `json:"id"`
 	Name     string           `json:"name"`
-	Labels   []stateLabel     `json:"labels,omitempty"`
+	Labels   []keyValue       `json:"labels,omitempty"`
 	Statuses []taskStatusInfo `json:"statuses,omitempty"`
 }
 

--- a/producers/interface.go
+++ b/producers/interface.go
@@ -71,6 +71,8 @@ type Dimensions struct {
 	FrameworkID        string            `json:"framework_id,omitempty"`
 	FrameworkRole      string            `json:"framework_role,omitempty"`
 	FrameworkPrincipal string            `json:"framework_principal,omitempty"`
+	TaskName           string            `json:"task_name,omitempty"`
+	TaskID             string            `json:"task_id,omitempty"`
 	Hostname           string            `json:"hostname"`
 	Labels             map[string]string `json:"labels,omitempty"` // map of arbitrary key/value pairs (aka "labels")
 }


### PR DESCRIPTION
This PR adds a task ID to the /containers/<container-id> endpoint in dcos-metrics.