### PR TITLE
DO NOT MERGE: Support Framework Authentication Mesos

### DIFF
--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -53,6 +53,10 @@ type Collector struct {
 	metricsChan chan producers.MetricsMessage
 	nodeInfo    collectors.NodeInfo
 	timestamp   int64
+
+	//basic auth
+	Principal string `yaml:"principal"`
+	Secret    string `yaml:"secret"`
 }
 
 // New creates a new instance of the Mesos agent collector (poller).

--- a/collectors/mesos/agent/container.go
+++ b/collectors/mesos/agent/container.go
@@ -83,6 +83,5 @@ func (c *Collector) getContainerMetrics() error {
 	}
 
 	c.HTTPClient.Timeout = HTTPTIMEOUT
-
-	return client.Fetch(c.HTTPClient, u, &c.containerMetrics)
+	return client.Fetch(c.HTTPClient, u, &c.containerMetrics, c.Principal, c.Secret)
 }

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -74,6 +74,5 @@ func (c *Collector) getAgentState() error {
 	}
 
 	c.HTTPClient.Timeout = HTTPTIMEOUT
-
-	return client.Fetch(c.HTTPClient, u, &c.agentState)
+	return client.Fetch(c.HTTPClient, u, &c.agentState, c.Principal, c.Secret)
 }

--- a/dcos-metrics.go
+++ b/dcos-metrics.go
@@ -46,6 +46,11 @@ func main() {
 	}
 	log.SetLevel(lvl)
 
+	//AuthConfig
+	if len(cfg.Collector.MesosAgent.Principal) > 0 {
+		log.Info("Framework authentication set to principal", cfg.Collector.MesosAgent.Principal)
+	}
+
 	// HTTP profiling
 	if cfg.Collector.HTTPProfiler {
 		log.Info("HTTP profiling enabled")

--- a/examples/configs/dcos-metrics-config-example.yaml
+++ b/examples/configs/dcos-metrics-config-example.yaml
@@ -5,14 +5,16 @@
 # Collector configuration
 collector:
   http_profiler: false
-  
+
   node:
-    poll_period: 15 
+    poll_period: 15
 
   mesos_agent:
     poll_period: 15
     port: 5051
     request_protocol: http
+    principal: dcos-metrics
+    secret: dcos-metrics-secret
 
 # Producers configuration
 producers:

--- a/util/http/client/client.go
+++ b/util/http/client/client.go
@@ -35,7 +35,7 @@ var (
 // way, Fetch() ensures that JSON is always unmarshaled the same way, and that
 // errors are handled correctly, but allows the returned data to be mapped to
 // an arbitrary struct that the caller is aware of.
-func Fetch(client *http.Client, url url.URL, target interface{}) error {
+func Fetch(client *http.Client, url url.URL, target interface{}, user string, pass string) error {
 	clientLog.Debug("Attempting to request data from ", url.String())
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
@@ -43,6 +43,7 @@ func Fetch(client *http.Client, url url.URL, target interface{}) error {
 	}
 
 	req.Header.Set("User-Agent", USERAGENT)
+	req.SetBasicAuth(user, pass)
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Do not merge in current state this PR is informational only for now and still under works.  There is a bug where if http credentials aren't provided it will not work. Will update PR in a bit.

Case: when you enable Mesos Authentication http://mesos.apache.org/documentation/latest/authentication/.  metrics cannot talk to mesos.  Here are changes to support provide basic authorization headers. 
