### PR TITLE
Draw container IDs in /containers from both container and app metrics

### DIFF
--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -51,7 +51,13 @@ func nodeHandler(p *producerImpl) http.HandlerFunc {
 func containersHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cm := []string{}
-		containerMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(producers.ContainerMetricPrefix) + ".*")
+		containerMetrics, err := p.store.GetByRegex(
+			fmt.Sprintf(
+				"(%s|%s).*",
+				regexp.QuoteMeta(producers.ContainerMetricPrefix),
+				regexp.QuoteMeta(producers.AppMetricPrefix),
+			),
+		)
 		if err != nil {
 			httpLog.Errorf("/v0/containers - %s", err.Error())
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/producers/http/handlers_test.go
+++ b/producers/http/handlers_test.go
@@ -171,18 +171,14 @@ func TestContainersHandler(t *testing.T) {
 			}
 			defer resp.Body.Close()
 
-			got, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				panic(err)
-			}
 			// Note that we didn't supply testContainerData in `setup` above.
-			expected, err := json.Marshal([]string{testContainerData.Dimensions.ContainerID})
-			if err != nil {
+			var containerIDs []string
+			if err := json.NewDecoder(resp.Body).Decode(&containerIDs); err != nil {
 				panic(err)
 			}
 
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
-			So(strings.TrimSpace(string(got)), ShouldEqual, strings.TrimSpace(string(expected)))
+			So(containerIDs, ShouldResemble, []string{testContainerData.Dimensions.ContainerID})
 		})
 	})
 }

--- a/producers/http/handlers_test.go
+++ b/producers/http/handlers_test.go
@@ -161,6 +161,27 @@ func TestContainersHandler(t *testing.T) {
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 			So(strings.TrimSpace(string(got)), ShouldEqual, strings.TrimSpace(string(expected)))
 		})
+		Convey("Should return container IDs when app metrics, but not container metrics, are present", func() {
+			port := setup([]producers.MetricsMessage{testNodeData, testAppData})
+			resp, err := http.Get(urlBuilder("localhost", port, "/v0/containers"))
+			if err != nil {
+				panic(err)
+			}
+			defer resp.Body.Close()
+
+			got, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				panic(err)
+			}
+			// Note that we didn't supply testContainerData in `setup` above.
+			expected, err := json.Marshal([]string{testContainerData.Dimensions.ContainerID})
+			if err != nil {
+				panic(err)
+			}
+
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(strings.TrimSpace(string(got)), ShouldEqual, strings.TrimSpace(string(expected)))
+		})
 	})
 }
 

--- a/producers/http/handlers_test.go
+++ b/producers/http/handlers_test.go
@@ -1,3 +1,5 @@
+//+build unit
+
 // Copyright 2016 Mesosphere, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/producers/http/handlers_test.go
+++ b/producers/http/handlers_test.go
@@ -87,7 +87,7 @@ var (
 		Timestamp: testTime.UTC().Unix(),
 	}
 
-	allTestData = []producers.MetricsMessage{
+	allTestMessages = []producers.MetricsMessage{
 		testNodeData,
 		testContainerData,
 		testAppData,
@@ -118,7 +118,7 @@ func setup(messages []producers.MetricsMessage) int {
 func TestNodeHandler(t *testing.T) {
 	Convey("When querying the /v0/node endpoint", t, func() {
 		Convey("Should return metrics in the expected structure", func() {
-			port := setup(allTestData)
+			port := setup(allTestMessages)
 			resp, err := http.Get(urlBuilder("localhost", port, "/v0/node"))
 			if err != nil {
 				panic(err)
@@ -144,7 +144,7 @@ func TestNodeHandler(t *testing.T) {
 func TestContainersHandler(t *testing.T) {
 	Convey("When querying the /v0/containers endpoint", t, func() {
 		Convey("Should return container IDs in the expected structure", func() {
-			port := setup(allTestData)
+			port := setup(allTestMessages)
 			resp, err := http.Get(urlBuilder("localhost", port, "/v0/containers"))
 			if err != nil {
 				panic(err)
@@ -190,7 +190,7 @@ func TestContainersHandler(t *testing.T) {
 func TestContainerHandler(t *testing.T) {
 	Convey("When querying the /v0/containers/{id} endpoint", t, func() {
 		Convey("Should return container metrics for the container ID given", func() {
-			port := setup(allTestData)
+			port := setup(allTestMessages)
 			resp, err := http.Get(urlBuilder("localhost", port, "/v0/containers/foo-container"))
 			if err != nil {
 				panic(err)
@@ -215,7 +215,7 @@ func TestContainerHandler(t *testing.T) {
 func TestContainerAppHandler(t *testing.T) {
 	Convey("When querying the /v0/containers/{id}/app endpoint", t, func() {
 		Convey("Should return app metrics in the expected structure", func() {
-			port := setup(allTestData)
+			port := setup(allTestMessages)
 			resp, err := http.Get(urlBuilder("localhost", port, "/v0/containers/foo-container/app"))
 			if err != nil {
 				panic(err)
@@ -240,7 +240,7 @@ func TestContainerAppHandler(t *testing.T) {
 func TestContainerAppMetricHandler(t *testing.T) {
 	Convey("When querying the /v0/containers/{id}/app/{metric-id} endpoint", t, func() {
 		Convey("Should return app metrics in the expected structure", func() {
-			port := setup(allTestData)
+			port := setup(allTestMessages)
 			resp, err := http.Get(urlBuilder("localhost", port, "/v0/containers/foo-container/app/some-app-metric"))
 			if err != nil {
 				panic(err)
@@ -265,7 +265,7 @@ func TestContainerAppMetricHandler(t *testing.T) {
 func TestPingHandler(t *testing.T) {
 	Convey("When querying the /v0/ping endpoint", t, func() {
 		Convey("Should return a message and a timestamp", func() {
-			port := setup(allTestData)
+			port := setup(allTestMessages)
 			resp, err := http.Get(urlBuilder("localhost", port, "/v0/ping"))
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
The `/containers` endpoint currently works by finding all container metrics in memory and returning the set of their container IDs. 

Unfortunately, it's possible for a container to exist which does not have associated container metrics (see https://issues.apache.org/jira/browse/MESOS-7918 for context). Since the ID for this container is never given in `/containers`, it cannot be discovered via the API. 

This PR updates the logic in the `/containers` handler. It now finds all container *and app* metrics in memory and returns the set of their container IDs. 