### PR TITLE
Avoid unregistering unknown containers.

### DIFF
--- a/mesos_module/isolator_module.cpp
+++ b/mesos_module/isolator_module.cpp
@@ -81,7 +81,13 @@ namespace metrics {
 
     process::Future<Nothing> cleanup(
         const mesos::ContainerID& container_id) {
-      container_assigner->unregister_container(container_id);
+      // If we are a nested container in the `DEBUG` class, then we don't
+      // emit metrics from this container and hence have nothing to cleanup.
+      if (!(container_id.has_parent() &&
+            container_config.has_container_class() &&
+            container_config.container_class() == ContainerClass::DEBUG)) {
+        container_assigner->unregister_container(container_id);
+      }
       return Nothing();
     }
 


### PR DESCRIPTION
For debug containers, metrics are not emitted and hence the
container is not registered with the `ContainerAssigner`
instance in the `prepare()` call on the `Isolator` interface.
Hence we should not try to unregister the container in `cleanup()`.

See https://github.com/apache/mesos/blob/11de04c1bbf65d0a90576642f8ea9574e05a317a/include/mesos/slave/isolator.hpp#L115-L124