### PR TITLE
Reinstate golint

### DIFF
--- a/config.go
+++ b/config.go
@@ -101,11 +101,7 @@ func (c *Config) loadConfig() error {
 		return err
 	}
 
-	if err = yaml.Unmarshal(fileByte, &c); err != nil {
-		return err
-	}
-
-	return nil
+	return yaml.Unmarshal(fileByte, &c)
 }
 
 func (c *Config) getNodeInfo(attemptSSL bool) error {

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -292,11 +292,7 @@ func (p *Plugin) loadConfig() error {
 		return err
 	}
 
-	if err = yaml.Unmarshal(fileByte, p); err != nil {
-		return err
-	}
-
-	return nil
+	return yaml.Unmarshal(fileByte, p)
 }
 
 // createClient creates an HTTP Client with credentials (if available) and

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -42,9 +42,9 @@ function _goimports {
 function _golint {
     local test_dirs="$1"
     local ignore_dirs="$2"
-    logmsg "Skipping 'go lint' ..."
-    # go get -u github.com/golang/lint/golint
-    # test -z "$(golint $test_dirs | grep -v vendor | grep -v $ignore_dirs | tee /dev/stderr)"
+    logmsg "Running 'go lint' ..."
+    go get -u github.com/golang/lint/golint
+    test -z "$(golint $test_dirs | grep -v vendor | grep -v $ignore_dirs | tee /dev/stderr)"
 }
 
 


### PR DESCRIPTION
This PR reinstates golint to the build (skipped in #118), and fixes two instances of the `return nil` issue flagged by the new rule. 