### PR TITLE
Add -u flag to all `go get`s in docs

### DIFF
--- a/examples/collector-emitter/README.md
+++ b/examples/collector-emitter/README.md
@@ -15,7 +15,7 @@ apt-get install golang-go
 
 ```bash
 go get -u github.com/dcos/dcos-metrics
-cd $GOPATH/src/github/dcos/dcos-metrics
+cd $GOPATH/src/github.com/dcos/dcos-metrics
 go generate # creates 'metrics_schema' package
 go build
 ```

--- a/examples/collector-emitter/README.md
+++ b/examples/collector-emitter/README.md
@@ -14,6 +14,8 @@ apt-get install golang-go
 ## Build
 
 ```bash
+go get -u github.com/dcos/dcos-metrics
+cd $GOPATH/src/github/dcos/dcos-metrics
 go generate # creates 'metrics_schema' package
 go build
 ```

--- a/plugins/datadog-standalone/README.md
+++ b/plugins/datadog-standalone/README.md
@@ -6,7 +6,7 @@ for those who do not wish to make use of the Datadog Agent.
 ## Installation
 
 ### Build this plugin (requires a Golang environment)
-1. `go get github.com/dcos/dcos-metrics`
+1. `go get -u github.com/dcos/dcos-metrics`
 1. `cd $(go env GOPATH)/src/github.com/dcos/dcos-metrics`
 1. `make && make plugins`
 

--- a/plugins/datadog/README.md
+++ b/plugins/datadog/README.md
@@ -4,7 +4,7 @@ This plugin supports sending metrics from the DC/OS metrics service on both mast
 ## Installation
 
 ### Build this plugin (requires a [Golang environment](https://golang.org/doc/install))
-1. `go get github.com/dcos/dcos-metrics`
+1. `go get -u github.com/dcos/dcos-metrics`
 1. `cd $(go env GOPATH)/src/github.com/dcos/dcos-metrics`
 1. `make && make plugins`
 

--- a/plugins/librato/README.md
+++ b/plugins/librato/README.md
@@ -4,7 +4,7 @@ This plugin supports sending metrics from the DC/OS metrics service on both mast
 ## Installation
 
 ### Build this plugin (requires a Golang environment)
-1. `go get github.com/dcos/dcos-metrics`
+1. `go get -u github.com/dcos/dcos-metrics`
 1. `cd $(go env GOPATH)/src/github.com/dcos/dcos-metrics`
 1. `make && make plugins`
 

--- a/plugins/stdout/README.md
+++ b/plugins/stdout/README.md
@@ -8,7 +8,7 @@ run it in production.
 ## Usage
 
 ### Build this plugin (requires a Golang environment)
-1. `go get github.com/dcos/dcos-metrics`
+1. `go get -u github.com/dcos/dcos-metrics`
 1. `cd $(go env GOPATH)/src/github.com/dcos/dcos-metrics`
 1. `make && make plugins`
 
@@ -24,6 +24,7 @@ build
 
 Upload the plugin to your node via `scp` or similar, then simply run
 
+`./dcos-metrics-stdout-plugin --dcos-role=agent`
 `./dcos-metrics-stdout-plugin --dcos-role=agent`
 
 The plugin will log every message it receives to stdout. 

--- a/plugins/stdout/README.md
+++ b/plugins/stdout/README.md
@@ -25,7 +25,6 @@ build
 Upload the plugin to your node via `scp` or similar, then simply run
 
 `./dcos-metrics-stdout-plugin --dcos-role=agent`
-`./dcos-metrics-stdout-plugin --dcos-role=agent`
 
 The plugin will log every message it receives to stdout. 
 


### PR DESCRIPTION
The -u flag pulls in all dependencies, ensuring that libraries like jason and logrus are available when the user comes to run `make`.

Thanks @frankscholten for the report!
