### PR TITLE
Add more container metrics from mesos

### DIFF
--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -147,10 +147,23 @@ var (
 				"source": "foo.adf2b6f4-a171-11e6-9182-080027fb5b88",
 				"statistics": {
 					"cpus_limit": 1.1,
+					"cpus_nr_periods": 3701894,
+					"cpus_nr_throttled": 2126,
 					"cpus_system_time_secs": 0.31,
+					"cpus_throttled_time_secs": 98.355904778,
 					"cpus_user_time_secs": 0.22,
+					"mem_anon_bytes": 435118080,
+					"mem_cache_bytes": 15962112,
+					"mem_critical_pressure_counter": 0,
+					"mem_file_bytes": 15962112,
 					"mem_limit_bytes": 167772160,
-					"mem_total_bytes": 4476928
+					"mem_low_pressure_counter": 0,
+					"mem_mapped_file_bytes": 40960,
+					"mem_medium_pressure_counter": 0,
+					"mem_rss_bytes": 435118080,
+					"mem_swap_bytes": 0,
+					"mem_total_bytes": 4476928,
+					"mem_unevictable_bytes": 0
 				}
 			}
 		]`)
@@ -338,7 +351,7 @@ func TestBuildDatapoints(t *testing.T) {
 				for _, container := range thisContainerMetrics {
 					result, err := coll.createContainerDatapoints(container)
 					So(err, ShouldEqual, nil)
-					So(len(result), ShouldEqual, 16)
+					So(len(result), ShouldEqual, 30)
 
 					cidRegistry := []string{}
 					for _, dp := range result {

--- a/collectors/mesos/agent/container.go
+++ b/collectors/mesos/agent/container.go
@@ -48,15 +48,32 @@ type agentContainer struct {
 // For a complete reference, see:
 // https://github.com/apache/mesos/blob/1.0.1/include/mesos/v1/mesos.proto#L921-L1022
 type resourceStatistics struct {
+
+	// Process and thread info
+	Processes uint32 `json:"processes,omitempty"`
+	Threads   uint32 `json:"threads,omitempty"`
+
 	// CPU usage info
 	CpusUserTimeSecs      float64 `json:"cpus_user_time_secs,omitempty"`
 	CpusSystemTimeSecs    float64 `json:"cpus_system_time_secs,omitempty"`
 	CpusLimit             float64 `json:"cpus_limit,omitempty"`
+	CpusNrPeriods         uint32  `json:"cpus_nr_periods,omitempty"`
+	CpusNrThrottled       uint32  `json:"cpus_nr_throttled,omitempty"`
 	CpusThrottledTimeSecs float64 `json:"cpus_throttled_time_secs,omitempty"`
 
 	// Memory info
-	MemTotalBytes uint64 `json:"mem_total_bytes,omitempty"`
-	MemLimitBytes uint64 `json:"mem_limit_bytes,omitempty"`
+	MemTotalBytes              uint64 `json:"mem_total_bytes,omitempty"`
+	MemTotalMemswBytes         uint64 `json:"mem_total_memsw_bytes,omitempty"`
+	MemLimitBytes              uint64 `json:"mem_limit_bytes,omitempty"`
+	MemSoftLimitBytes          uint64 `json:"mem_soft_limit_bytes,omitempty"`
+	MemCacheBytes              uint64 `json:"mem_cache_bytes,omitempty"`
+	MemRssBytes                uint64 `json:"mem_rss_bytes,omitempty"`
+	MemMappedFileBytes         uint64 `json:"mem_mapped_file_bytes,omitempty"`
+	MemSwapBytes               uint64 `json:"mem_swap_bytes,omitempty"`
+	MemUnevictableBytes        uint64 `json:"mem_unevictable_bytes,omitempty"`
+	MemLowPressureCounter      uint64 `json:"mem_low_pressure_counter,omitempty"`
+	MemMediumPressureCounter   uint64 `json:"mem_medium_pressure_counter,omitempty"`
+	MemCriticalPressureCounter uint64 `json:"mem_critical_pressure_counter,omitempty"`
 
 	// Disk info
 	DiskLimitBytes uint64 `json:"disk_limit_bytes,omitempty"`

--- a/collectors/mesos/agent/metrics.go
+++ b/collectors/mesos/agent/metrics.go
@@ -61,6 +61,18 @@ func (c *Collector) createContainerDatapoints(container agentContainer) ([]produ
 
 	addDps := []producers.Datapoint{
 		producers.Datapoint{
+			Name:  "processes",
+			Value: container.Statistics.Processes,
+			Unit:  count,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "threads",
+			Value: container.Statistics.Threads,
+			Unit:  count,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
 			Name:  "cpus.user.time",
 			Value: container.Statistics.CpusUserTimeSecs,
 			Unit:  seconds,
@@ -79,6 +91,18 @@ func (c *Collector) createContainerDatapoints(container agentContainer) ([]produ
 			Tags:  dpTags,
 		},
 		producers.Datapoint{
+			Name:  "cpus.nr.periods",
+			Value: container.Statistics.CpusNrPeriods,
+			Unit:  count,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "cpus.nr.throttled",
+			Value: container.Statistics.CpusNrThrottled,
+			Unit:  count,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
 			Name:  "cpus.throttled.time",
 			Value: container.Statistics.CpusThrottledTimeSecs,
 			Unit:  seconds,
@@ -91,9 +115,69 @@ func (c *Collector) createContainerDatapoints(container agentContainer) ([]produ
 			Tags:  dpTags,
 		},
 		producers.Datapoint{
+			Name:  "mem.total.memsw",
+			Value: container.Statistics.MemTotalMemswBytes,
+			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
 			Name:  "mem.limit",
 			Value: container.Statistics.MemLimitBytes,
 			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.soft.limit",
+			Value: container.Statistics.MemSoftLimitBytes,
+			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.cache",
+			Value: container.Statistics.MemCacheBytes,
+			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.rss",
+			Value: container.Statistics.MemRssBytes,
+			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.mapped.file",
+			Value: container.Statistics.MemMappedFileBytes,
+			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.swap",
+			Value: container.Statistics.MemSwapBytes,
+			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.unevictable",
+			Value: container.Statistics.MemUnevictableBytes,
+			Unit:  bytes,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.low.pressure",
+			Value: container.Statistics.MemLowPressureCounter,
+			Unit:  count,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.medium.pressure",
+			Value: container.Statistics.MemMediumPressureCounter,
+			Unit:  count,
+			Tags:  dpTags,
+		},
+		producers.Datapoint{
+			Name:  "mem.critical.pressure",
+			Value: container.Statistics.MemCriticalPressureCounter,
+			Unit:  count,
 			Tags:  dpTags,
 		},
 		producers.Datapoint{


### PR DESCRIPTION
This patch will introduce more container metrics available from Mesos to be
exposed. DCOS_OSS-1607 has more deatils about metrics exposed and link to the
related definitions in Mesos.

https://jira.mesosphere.com/browse/DCOS_OSS-1607