### PR TITLE
http authentication support for marathon/mesos

### DIFF
--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -55,6 +55,10 @@ type Collector struct {
 	nodeInfo          collectors.NodeInfo
 	timestamp         int64
 	ContainerTaskRels *ContainerTaskRels
+
+	//basic auth
+	Principal string `yaml:"principal"`
+	Secret    string `yaml:"secret"`
 }
 
 // ContainerTaskRels defines the relationship between containers and tasks.

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -532,6 +532,19 @@ func TestGetLabelsByContainerID(t *testing.T) {
 							},
 						},
 					},
+					executorInfo{
+						Container: "containerWithLongLabelID",
+						Labels: []executorLabels{
+							executorLabels{
+								Key:   "somekey",
+								Value: "someval",
+							},
+							executorLabels{
+								Key:   "longkey",
+								Value: "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+							},
+						},
+					},
 				},
 			},
 		}

--- a/collectors/mesos/agent/container.go
+++ b/collectors/mesos/agent/container.go
@@ -83,6 +83,5 @@ func (c *Collector) getContainerMetrics() error {
 	}
 
 	c.HTTPClient.Timeout = HTTPTIMEOUT
-
-	return client.Fetch(c.HTTPClient, u, &c.containerMetrics)
+	return client.Fetch(c.HTTPClient, u, &c.containerMetrics, c.Principal, c.Secret)
 }

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -106,6 +106,5 @@ func (c *Collector) getAgentState() error {
 	}
 
 	c.HTTPClient.Timeout = HTTPTIMEOUT
-
-	return client.Fetch(c.HTTPClient, u, &c.agentState)
+	return client.Fetch(c.HTTPClient, u, &c.agentState, c.Principal, c.Secret)
 }

--- a/config.go
+++ b/config.go
@@ -54,7 +54,6 @@ type Config struct {
 	Producers         ProducersConfig `yaml:"producers"`
 	IAMConfigPath     string          `yaml:"iam_config_path"`
 	CACertificatePath string          `yaml:"ca_certificate_path"`
-
 	// Node info
 	nodeInfo collectors.NodeInfo
 
@@ -124,6 +123,10 @@ func (c *Config) getNodeInfo(attemptSSL bool) error {
 	}
 	if useSSL {
 		stateURL.Scheme = "https"
+	}
+
+	if len(c.Collector.MesosAgent.Principal) > 0 {
+		stateURL.User = url.UserPassword(c.Collector.MesosAgent.Principal, c.Collector.MesosAgent.Secret)
 	}
 
 	// Create a new DC/OS nodeutil instance
@@ -218,7 +221,7 @@ func getNewConfig(args []string) (Config, error) {
 		}, "\n"))
 		os.Exit(0)
 	}
-
+	log.Info("Configpath: ", c.ConfigPath)
 	if len(c.ConfigPath) > 0 {
 		if err := c.loadConfig(); err != nil {
 			return c, err

--- a/dcos-metrics.go
+++ b/dcos-metrics.go
@@ -45,6 +45,11 @@ func main() {
 	}
 	log.SetLevel(lvl)
 
+	//AuthConfig
+	if len(cfg.Collector.MesosAgent.Principal) > 0 {
+		log.Info("Framework authentication set to principal", cfg.Collector.MesosAgent.Principal)
+	}
+
 	// HTTP profiling
 	if cfg.Collector.HTTPProfiler {
 		log.Info("HTTP profiling enabled")

--- a/examples/configs/dcos-metrics-config-example.yaml
+++ b/examples/configs/dcos-metrics-config-example.yaml
@@ -5,7 +5,7 @@
 # Collector configuration
 collector:
   http_profiler: false
-  
+
   node:
     poll_period: 15s
 
@@ -13,6 +13,8 @@ collector:
     poll_period: 15s
     port: 5051
     request_protocol: http
+    principal: dcos-metrics
+    secret: dcos-metrics-secret
 
 # Producers configuration
 producers:

--- a/util/http/client/client.go
+++ b/util/http/client/client.go
@@ -35,7 +35,7 @@ var (
 // way, Fetch() ensures that JSON is always unmarshaled the same way, and that
 // errors are handled correctly, but allows the returned data to be mapped to
 // an arbitrary struct that the caller is aware of.
-func Fetch(client *http.Client, url url.URL, target interface{}) error {
+func Fetch(client *http.Client, url url.URL, target interface{}, user string, pass string) error {
 	clientLog.Debug("Attempting to request data from ", url.String())
 	req, err := http.NewRequest("GET", url.String(), nil)
 	if err != nil {
@@ -43,6 +43,9 @@ func Fetch(client *http.Client, url url.URL, target interface{}) error {
 	}
 
 	req.Header.Set("User-Agent", USERAGENT)
+	if user != "" || pass != "" {
+		req.SetBasicAuth(user, pass)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Case: when you enable Mesos Authentication http://mesos.apache.org/documentation/latest/authentication/. metrics cannot talk to mesos. Here are changes to support provide basic authorization headers.

```
Environment=MESOS_AUTHENTICATE_HTTP_READONLY=true
Environment=MESOS_AUTHENTICATE_HTTP_READWRITE=true
Environment=MESOS_AUTHENTICATE_HTTP_FRAMEWORKS=true
Environment=MESOS_HTTP_FRAMEWORK_AUTHENTICATORS=basic
```

dcos-metrics cannot authenticate properly (401).

ERRORS:
```
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [DEBUG] bootstrapping dcos-metrics-master
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Opening /var/lib/dcos for locking
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Opening /var/lib/dcos
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Opened /var/lib/dcos with fd 7
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Taking exclusive lock on /var/lib/dcos
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Locking fd 7
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Locked fd 7
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Reaching consensus about znode /cluster-id
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Consensus znode /cluster-id already exists
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Cluster ID in ZooKeeper and file are the same: da6573c2-dcaf-4d87-b809-94dedbdc683a
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Unlocked fd 7
Jul 18 21:55:24 ip-10-68-134-16 bootstrap[12174]: [INFO] Closing /var/lib/dcos with fd 7
Jul 18 21:55:24 ip-10-68-134-16 systemd[1]: Started DC/OS Metrics Master: exposes node metrics.
Jul 18 21:55:24 ip-10-68-134-16 dcos-metrics[12183]: time="2017-07-18T21:55:24Z" level=warning msg="No config file specified, using all defaults."
Jul 18 21:55:24 ip-10-68-134-16 dcos-metrics[12183]: time="2017-07-18T21:55:24Z" level=fatal msg="error: could not get Mesos node ID: GET request to http://leader.mesos:5050/state returned response code 401"
```
This PR allows options so you can override the default authentication options with basic credentials.

configuration:
```
collector:
  mesos_agent:
    principal: <principalid>
    secret: <principal secret>
```
To default to token based auth just leave configuration blank and metrics will function as normal.