### PR TITLE
Fix Prometheus output

### DIFF
--- a/plugins/prometheus/prometheus.go
+++ b/plugins/prometheus/prometheus.go
@@ -50,7 +50,7 @@ type metricsSnapshot struct {
 }
 
 func main() {
-	log.Info("Starting statsd DC/OS metrics plugin")
+	log.Info("Starting Prometheus DC/OS metrics plugin")
 
 	promPlugin, err := plugin.New(
 		plugin.Name("prometheus"),

--- a/plugins/prometheus/prometheus.go
+++ b/plugins/prometheus/prometheus.go
@@ -161,13 +161,13 @@ func getLabelsForDatapoint(dimensions producers.Dimensions, tags map[string]stri
 	labels := []string{}
 	for k, v := range allDimensions {
 		if len(v) > 0 {
-			labels = append(labels, fmt.Sprintf("%s:%q", k, v))
+			labels = append(labels, fmt.Sprintf("%s=%q", k, v))
 		}
 	}
 	// Sorting tags ensures consistent order
 	for _, pair := range prodHelpers.SortTags(tags) {
 		k, v := pair[0], pair[1]
-		labels = append(labels, fmt.Sprintf("%s:%q", k, v))
+		labels = append(labels, fmt.Sprintf("%s=%q", k, v))
 	}
 
 	if len(labels) > 0 {

--- a/plugins/prometheus/prometheus_test.go
+++ b/plugins/prometheus/prometheus_test.go
@@ -93,8 +93,8 @@ func TestConversion(t *testing.T) {
 
 	Convey("When converting metrics with dimensions", t, func() {
 		text := messageToPromText(fooBarMetricWithDimensions)
-		So(text, ShouldContainSubstring, "foo_bar{task_id:\"task-id-here\"} 123 1262390462000")
-		So(text, ShouldContainSubstring, "foo_baz{task_id:\"task-id-here\",frodo:\"baggins\",samwise:\"gamgee\"} 123.5 1262390462000")
+		So(text, ShouldContainSubstring, "foo_bar{task_id=\"task-id-here\"} 123 1262390462000")
+		So(text, ShouldContainSubstring, "foo_baz{task_id=\"task-id-here\",frodo=\"baggins\",samwise=\"gamgee\"} 123.5 1262390462000")
 	})
 }
 

--- a/plugins/prometheus/prometheus_test.go
+++ b/plugins/prometheus/prometheus_test.go
@@ -36,7 +36,7 @@ var (
 				Timestamp: "2010-01-02T00:01:02.000000003Z",
 			},
 			producers.Datapoint{
-				Name:      "foo.baz",
+				Name:      "foo-baz",
 				Value:     123.5,
 				Unit:      "",
 				Timestamp: "2010-01-02T00:01:02.000000003Z",
@@ -73,8 +73,8 @@ var (
 				Unit:      "",
 				Timestamp: "2010-01-02T00:01:02.000000003Z",
 				Tags: map[string]string{
-					"frodo":   "baggins",
-					"samwise": "gamgee",
+					"frodo":    "baggins",
+					"sam-wise": "gam-gee",
 				},
 			},
 		},
@@ -94,7 +94,7 @@ func TestConversion(t *testing.T) {
 	Convey("When converting metrics with dimensions", t, func() {
 		text := messageToPromText(fooBarMetricWithDimensions)
 		So(text, ShouldContainSubstring, "foo_bar{task_id=\"task-id-here\"} 123 1262390462000")
-		So(text, ShouldContainSubstring, "foo_baz{task_id=\"task-id-here\",frodo=\"baggins\",samwise=\"gamgee\"} 123.5 1262390462000")
+		So(text, ShouldContainSubstring, "foo_baz{task_id=\"task-id-here\",frodo=\"baggins\",sam_wise=\"gam-gee\"} 123.5 1262390462000")
 	})
 }
 


### PR DESCRIPTION
This PR fixes three issues:
 - The plugin printed 'Starting statsd DC/OS metrics plugin' thanks to a copypaste error
 - The plugin did not properly sanitise metric names, so hyphens could creep in and cause issues
 - The plugin used colons instead of equals signs for labels

With these issues fixed, kafka and cassandra metrics are properly reported. 