### PR TITLE
Poll the metrics API via a system socket instead of adminrouter

### DIFF
--- a/plugins/CONTRIBUTING.md
+++ b/plugins/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Don't see your desired plugin on this list? Make a PR and add it!
 
 - [ ] Elastic Search
 - [ ] InfluxDB
-- [ ] Prometheus
+- [x] Prometheus
 - [ ] SignalFX
 
 ## Where to start?

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,38 +1,45 @@
 ## DC/OS Metrics Service Plugins
-**NOTE** These plugins are considered experimental and are not supported by the DC/OS support team. If you're having issues, please feel free to file an issue to this repo (not github.com/dcos/dcos) or file a *Pull Request* (we love pull requests!).
 
-Though your mileage may vary, if there is a plugin missing that you need, please feel free to file an issue so we can poll what services our users want the most.
+DC/OS Metrics Plugins are the best way to get your metrics from DC/OS to your monitoring platform.
 
-## Developing
-To develop a new plugin in preparation for a pull request to this project:
+Plugins are binaries which you run on each node in your DC/OS cluster. There they monitor the DC/OS Metrics API,
+aggregating, transforming, and pushing or offering them as appropriate.
 
-### Plugin Development
-1. Create a new package for your `cool` plugin `mkdir plugins/cool/`
-1. Make a go file named after your package `touch plugins/cool/cool.go`
+The following plugins are available:
+ - [Datadog Agent](./datadog) - sends your metrics to the Datadog Agent
+ - [Datadog Standalone](./datadog-standalone) - sends your metrics straight to DatadogHQ
+ - [Librato](./librato) - sends your metrics to Librato
+ - [Prometheus](./prometheus) - serves prometheus-format metrics
+ - [StatsD](./statsd) - sends your metrics to a StatsD server
+ - [stdout](./stdout) - prints your metrics to stdout
 
-#### Get a new plugin.Plugin{}
-1. Create flags: `myFlags := []cli.Flag{}`
-1. `myPlugin := plugin.New(myFlags)` -> `plugin.Plugin{}`
-1. Use `myPlugin.App.Action` and pass it a [cli.ActionFunc()](https://github.com/urfave/cli/blob/master/app.go#L66) which has all the `main()` logic your plugin needs.
-1. Call `myPlugin.Metrics()` which returns a slice of `producers.MetricsMessage{}` from the metrics HTTP API.
+Missing a plugin? You can get in touch with the team and ask us to write a new one, or you can
+[write your own](#Developing).
 
-At this point you can write what ever helper methods you need to transform these and send to your metrics aggregation or cloud hosted service.
+### Installation
+Plugins can be installed on each node.
 
-### Unit Test Coverage
-1. Add a unit test (aim for 80% coverage)
+The binaries can be obtained from the [releases page](https://github.com/dcos/dcos-metrics/releases), or built from
+source according to preference. The binary should be copied to the `/opt/mesosphere/bin` directory on each node.
 
-#### Add a README.md in your `cool` package explaining:
-```
-vi plugins/cool/README.md
-# The Cool Plugin
-This cool plugin allows you to plugin to cool stuff.
+Each plugin has (or will soon have) a `systemd` directory containing systemd unit files for the master and agent.
+These should be downloaded, edited as appropriate - each plugin has its own flags where you may need to define API
+keys or make customisations - and then uploaded to the /etc/systemd/system` directory on each node.
 
-# How To Run Me
-1. ...
+This done, the new systemd service should be added and started (`systemctl daemon-reload && systemctl start <plugin>`)
 
-# Caveats
-I knew there were caveats!
-```
+### Compatibility
+Regardless of the release to which they are attached, all plugins are compatible with DC/OS 1.9 and above.
 
-#### Submit a Pull Request!
-Ping @malnick on DC/OS community slack :)
+### The future
+In 1.11, a new and improved metrics API will be available which should make plugins much easier to write and install.
+
+When that happens, the plugins that reside in this directory will be deprecated. They will continue to work. New plugins
+using the updated API will be developed and released to replace them.
+
+In later versions of DC/OS, we expect these plugins to cease to function as the API on which they depend will no longer
+be available.
+
+### Developing
+See [CONTRIBUTING.md](./CONTRIBUTING.md)
+

--- a/plugins/option.go
+++ b/plugins/option.go
@@ -15,16 +15,8 @@
 package plugin
 
 import (
-	"errors"
-
 	"github.com/dcos/dcos-metrics/producers"
 	"github.com/urfave/cli"
-)
-
-var (
-	errBadProto = errors.New("Protocol can be either http or https only")
-	errBadPort  = errors.New("Port must be less than 65535")
-	errBadToken = errors.New("Port token can not have zero length")
 )
 
 // Option lets each plugin configure the Plugin type. The plugin.New(...)
@@ -47,39 +39,6 @@ func PollingInterval(i int) Option {
 	return func(p *Plugin) error {
 		p.PollingInterval = i
 		return nil
-	}
-}
-
-// MetricsProtocol allows the plugin to set either "http" or "https" for the url
-// it calls to gather metrics.
-func MetricsProtocol(proto string) Option {
-	return func(p *Plugin) error {
-		if proto == "http" || proto == "https" {
-			p.MetricsScheme = proto
-			return nil
-		}
-		return errBadProto
-	}
-}
-
-// MetricsHost allows the plugin to set a custom hostname for the url it calls
-// to gather metrics.
-func MetricsHost(h string) Option {
-	return func(p *Plugin) error {
-		p.MetricsHost = h
-		return nil
-	}
-}
-
-// MetricsPort allows the plugin to set a custom port for the url it calls to
-// gather metrics.
-func MetricsPort(port int) Option {
-	return func(p *Plugin) error {
-		if port <= 65535 {
-			p.MetricsPort = port
-			return nil
-		}
-		return errBadPort
 	}
 }
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -224,17 +224,18 @@ func makeMetricsRequest(client *http.Client, url string) (producers.MetricsMessa
 		l.Errorf("Encountered error requesting data, %s", err.Error())
 		return mm, err
 	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		l.Errorf("Encountered error reading response body, %s", err.Error())
-		return mm, err
-	}
 
 	// 204 No Content is not an error code; we handle it explicitly
 	if resp.StatusCode == http.StatusNoContent {
 		l.Warnf("Empty response received from endpoint: %s", url)
 		return mm, nil
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		l.Errorf("Encountered error reading response body, %s", err.Error())
+		return mm, err
 	}
 
 	err = json.Unmarshal(body, &mm)

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -39,9 +39,6 @@ type Plugin struct {
 	Endpoints       []string
 	Role            string
 	PollingInterval int
-	MetricsPort     int
-	MetricsScheme   string
-	MetricsHost     string
 	Log             *logrus.Entry
 	ConnectorFunc   func([]producers.MetricsMessage, *cli.Context) error
 	BeforeFunc      func(*cli.Context) error
@@ -57,39 +54,17 @@ func New(options ...Option) (*Plugin, error) {
 	newPlugin := &Plugin{
 		Name:            "default",
 		PollingInterval: 10,
-		MetricsScheme:   "http",
-		MetricsHost:     "localhost",
-		MetricsPort:     61001,
 	}
 
 	newPlugin.App = cli.NewApp()
 	newPlugin.App.Version = version
 	newPlugin.App.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:        "metrics-host",
-			Value:       newPlugin.MetricsHost,
-			Usage:       "The IP or hostname where DC/OS metrics is running",
-			Destination: &newPlugin.MetricsHost,
-		},
-		cli.StringFlag{
-			Name:        "metrics-proto",
-			Value:       newPlugin.MetricsScheme,
-			Usage:       "The HTTP protocol for the DC/OS metrics service",
-			Destination: &newPlugin.MetricsScheme,
-		},
-		cli.IntFlag{
-			Name:        "metrics-port",
-			Value:       newPlugin.MetricsPort,
-			Usage:       "Port the DC/OS metrics service is running.Defaults to agent adminrouter port",
-			Destination: &newPlugin.MetricsPort,
-		},
 		cli.IntFlag{
 			Name:        "polling-interval",
 			Value:       newPlugin.PollingInterval,
 			Usage:       "Polling interval for metrics in seconds",
 			Destination: &newPlugin.PollingInterval,
 		},
-
 		cli.StringFlag{
 			Name:        "dcos-role",
 			Value:       newPlugin.Role,

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -155,11 +155,8 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 
 // getNodeMetrics queries the /node endpoint and returns metrics found there
 func (p *Plugin) getNodeMetrics() (producers.MetricsMessage, error) {
-	nodeMetrics, err := makeMetricsRequest(p.Client, "http://localhost/v0/node")
-	if err != nil {
-		return nodeMetrics, errors.Wrap(err, "could not read node metrics")
-	}
-	return nodeMetrics, nil
+	message, err := makeMetricsRequest(p.Client, "http://localhost/v0/node")
+	return message, errors.Wrap(err, "could not read node metrics")
 }
 
 // getContainerMetrics queries the /containers/<id> and /containers/<id>/app

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -163,22 +164,23 @@ func (p *Plugin) getNodeMetrics() (producers.MetricsMessage, error) {
 // endpoint for each container on the machine. It returns a slice of metrics
 // messages, one for each hit.
 func (p *Plugin) getContainerMetrics() ([]producers.MetricsMessage, error) {
-	var messages []producers.MetricsMessage
 	ids, err := p.getContainerList()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read list of containers")
 	}
+
+	var futures []<-chan producers.MetricsMessage
 	for _, id := range ids {
-		containerMetrics, err := makeMetricsRequest(p.Client, fmt.Sprintf("http://localhost/v0/containers/%s", id))
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not retrieve metrics for container %s", id)
-		}
-		containerAppMetrics, err := makeMetricsRequest(p.Client, fmt.Sprintf("http://localhost/v0/containers/%s/app", id))
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not retrieve app metrics for container %s", id)
-		}
-		messages = append(messages, containerMetrics, containerAppMetrics)
+		url1 := fmt.Sprintf("http://localhost/v0/containers/%s", id)
+		url2 := fmt.Sprintf("http://localhost/v0/containers/%s/app", id)
+		futures = append(futures, makeMetricsRequestFuture(p.Client, url1), makeMetricsRequestFuture(p.Client, url2))
 	}
+
+	var messages []producers.MetricsMessage
+	for future := range mergeFutures(futures) {
+		messages = append(messages, future)
+	}
+
 	return messages, nil
 }
 
@@ -198,6 +200,45 @@ func (p *Plugin) getContainerList() ([]string, error) {
 }
 
 /*** Helpers ***/
+
+// mergeFutures aggregates multiple channels into a single output channel
+func mergeFutures(cs []<-chan producers.MetricsMessage) <-chan producers.MetricsMessage {
+	var wg sync.WaitGroup
+	out := make(chan producers.MetricsMessage)
+
+	// Start an output goroutine for each input channel in cs.  output
+	// copies values from c to out until c is closed, then calls wg.Done.
+	output := func(c <-chan producers.MetricsMessage) {
+		for n := range c {
+			out <- n
+		}
+		wg.Done()
+	}
+	wg.Add(len(cs))
+	for _, c := range cs {
+		go output(c)
+	}
+
+	// Start a goroutine to close out once all the output goroutines are
+	// done.  This must start after the wg.Add call.
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+	return out
+}
+
+// makeMetricsRequestFuture wraps makeMetricsRequest in a goroutine, returning
+// a channel on which the MetricsMessage will be returned.
+func makeMetricsRequestFuture(client *http.Client, url string) <-chan producers.MetricsMessage {
+	out := make(chan producers.MetricsMessage, 1)
+	go func() {
+		message, _ := makeMetricsRequest(client, url)
+		out <- message
+		close(out)
+	}()
+	return out
+}
 
 // makeMetricsRequest queries the given url expecting to find a JSON-formatted
 // MetricsMessage, which it returns.

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -90,7 +90,9 @@ func New(options ...Option) (*Plugin, error) {
 func (p *Plugin) StartPlugin() error {
 	p.App.Before = func(c *cli.Context) error {
 		if p.BeforeFunc != nil {
-			return p.BeforeFunc(c)
+			if err := p.BeforeFunc(c); err != nil {
+				return err
+			}
 		}
 		if p.Role == dcos.RoleMaster || p.Role == dcos.RoleAgent || p.Role == dcos.RoleAgentPublic {
 			return p.createClient()
@@ -101,7 +103,9 @@ func (p *Plugin) StartPlugin() error {
 	}
 	p.App.After = func(c *cli.Context) error {
 		if p.AfterFunc != nil {
-			return p.AfterFunc(c)
+			if err := p.AfterFunc(c); err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -165,9 +165,6 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 	// The first time Metrics() is called, the plugin client
 	// should be initialised
 	if p.Client == nil {
-		if err := p.loadConfig(); err != nil {
-			return metricsMessages, err
-		}
 		if err := p.createClient(); err != nil {
 			return metricsMessages, err
 		}
@@ -290,23 +287,6 @@ func makeMetricsRequest(client *http.Client, request *http.Request) (producers.M
 	}
 
 	return mm, nil
-}
-
-// loadConfig loads the CACertPath and IAMConfig from the specified yaml file
-// into the corresponding Plugin struct fields
-func (p *Plugin) loadConfig() error {
-	// ConfigPath is optional; don't attempt to read it if not supplied
-	if p.ConfigPath == "" {
-		p.Log.Info("No --config flag was supplied; metrics requests will not be authenticated and may fail")
-		return nil
-	}
-	p.Log.Info("Loading optional authentication configuration")
-	fileByte, err := ioutil.ReadFile(p.ConfigPath)
-	if err != nil {
-		return err
-	}
-
-	return yaml.Unmarshal(fileByte, p)
 }
 
 // createClient creates an HTTP Client which uses the unix file socket

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -101,7 +101,7 @@ func (p *Plugin) StartPlugin() error {
 	}
 	p.App.After = func(c *cli.Context) error {
 		if p.AfterFunc != nil {
-			return p.BeforeFunc(c)
+			return p.AfterFunc(c)
 		}
 		return nil
 	}

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -128,7 +128,7 @@ func (p *Plugin) StartPlugin() error {
 	return p.App.Run(os.Args)
 }
 
-// Metrics polls the local dcos-metrics API and returns a slice of
+// Metrics queries the local dcos-metrics API and returns a slice of
 // producers.MetricsMessage.
 func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 	var messages []producers.MetricsMessage
@@ -154,7 +154,7 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 	return messages, nil
 }
 
-// getNodeMetrics polls the /node endpoint and returns metrics found there
+// getNodeMetrics queries the /node endpoint and returns metrics found there
 func (p *Plugin) getNodeMetrics() (producers.MetricsMessage, error) {
 	nodeMetrics, err := makeMetricsRequest(p.Client, "http://localhost/v0/node")
 	if err != nil {
@@ -163,7 +163,7 @@ func (p *Plugin) getNodeMetrics() (producers.MetricsMessage, error) {
 	return nodeMetrics, nil
 }
 
-// getContainerMetrics polls the /containers/<id> and /containers/<id>/app
+// getContainerMetrics queries the /containers/<id> and /containers/<id>/app
 // endpoint for each container on the machine. It returns a slice of metrics
 // messages, one for each hit.
 func (p *Plugin) getContainerMetrics() ([]producers.MetricsMessage, error) {
@@ -186,7 +186,7 @@ func (p *Plugin) getContainerMetrics() ([]producers.MetricsMessage, error) {
 	return messages, nil
 }
 
-// getContainerList polls the /containers endpoint and returns a slice of
+// getContainerList queries the /containers endpoint and returns a slice of
 // container IDs.
 func (p *Plugin) getContainerList() ([]string, error) {
 	var ids []string
@@ -211,7 +211,7 @@ func (p *Plugin) getContainerList() ([]string, error) {
 
 /*** Helpers ***/
 
-// makeMetricsRequest polls the given url expecting to find a JSON-formatted
+// makeMetricsRequest queries the given url expecting to find a JSON-formatted
 // MetricsMessage, which it returns.
 func makeMetricsRequest(client *http.Client, url string) (producers.MetricsMessage, error) {
 	l := logrus.WithFields(logrus.Fields{"plugin": "http-helper"})

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -216,7 +216,7 @@ func (p *Plugin) getContainerList() ([]string, error) {
 func makeMetricsRequest(client *http.Client, url string) (producers.MetricsMessage, error) {
 	l := logrus.WithFields(logrus.Fields{"plugin": "http-helper"})
 
-	l.Infof("Making request to %+v", url)
+	l.Infof("Making request to %s", url)
 	mm := producers.MetricsMessage{}
 
 	resp, err := client.Get(url)
@@ -233,7 +233,7 @@ func makeMetricsRequest(client *http.Client, url string) (producers.MetricsMessa
 
 	// 204 No Content is not an error code; we handle it explicitly
 	if resp.StatusCode == http.StatusNoContent {
-		l.Warnf("Empty response received from endpoint: %+v", url)
+		l.Warnf("Empty response received from endpoint: %s", url)
 		return mm, nil
 	}
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -118,7 +119,12 @@ func (p *Plugin) StartPlugin() error {
 		if p.BeforeFunc != nil {
 			return p.BeforeFunc(c)
 		}
-		return p.createClient()
+		if p.Role == dcos.RoleMaster || p.Role == dcos.RoleAgent || p.Role == dcos.RoleAgentPublic {
+			return p.createClient()
+		}
+		return fmt.Errorf(
+			"--dcos-role %q was not recognized (valid roles: %s, %s, %s)",
+			p.Role, dcos.RoleMaster, dcos.RoleAgent, dcos.RoleAgentPublic)
 	}
 	p.App.After = func(c *cli.Context) error {
 		if p.AfterFunc != nil {

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -136,7 +136,7 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 	// Fetch node metrics
 	nodeMetrics, err := p.getNodeMetrics()
 	if err != nil {
-		return messages, err
+		return nil, err
 	}
 	messages = append(messages, nodeMetrics)
 
@@ -148,7 +148,7 @@ func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 	// Fetch container metrics
 	containerMetrics, err := p.getContainerMetrics()
 	if err != nil {
-		return messages, err
+		return nil, err
 	}
 	messages = append(messages, containerMetrics...)
 	return messages, nil
@@ -170,16 +170,16 @@ func (p *Plugin) getContainerMetrics() ([]producers.MetricsMessage, error) {
 	var messages []producers.MetricsMessage
 	ids, err := p.getContainerList()
 	if err != nil {
-		return messages, errors.Wrap(err, "could not read list of containers")
+		return nil, errors.Wrap(err, "could not read list of containers")
 	}
 	for _, id := range ids {
 		containerMetrics, err := makeMetricsRequest(p.Client, fmt.Sprintf("http://localhost/v0/containers/%s", id))
 		if err != nil {
-			return messages, errors.Wrapf(err, "could not retrieve metrics for container %s", id)
+			return nil, errors.Wrapf(err, "could not retrieve metrics for container %s", id)
 		}
 		containerAppMetrics, err := makeMetricsRequest(p.Client, fmt.Sprintf("http://localhost/v0/containers/%s/app", id))
 		if err != nil {
-			return messages, errors.Wrapf(err, "could not retrieve app metrics for container %s", id)
+			return nil, errors.Wrapf(err, "could not retrieve app metrics for container %s", id)
 		}
 		messages = append(messages, containerMetrics, containerAppMetrics)
 	}
@@ -193,17 +193,17 @@ func (p *Plugin) getContainerList() ([]string, error) {
 
 	resp, err := p.Client.Get("http://localhost/v0/containers")
 	if err != nil {
-		return ids, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		p.Log.Errorf("Encountered error reading response body, %s", err.Error())
-		return ids, err
+		return nil, err
 	}
 	if err := json.Unmarshal(body, &ids); err != nil {
-		return ids, err
+		return nil, err
 	}
 
 	return ids, nil

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -30,29 +30,24 @@ import (
 	"github.com/dcos/dcos-go/dcos"
 	"github.com/dcos/dcos-metrics/producers"
 	"github.com/urfave/cli"
-
-	yaml "gopkg.in/yaml.v2"
 )
 
 // Plugin is used to collect metrics and then send them to a remote system
 // (e.g. DataDog, Librato, etc.).  Use plugin.New(...) to build a new plugin.
 type Plugin struct {
-	App               *cli.App
-	Name              string
-	Endpoints         []string
-	Role              string
-	PollingInterval   int
-	MetricsPort       int
-	MetricsScheme     string
-	MetricsHost       string
-	Log               *logrus.Entry
-	ConnectorFunc     func([]producers.MetricsMessage, *cli.Context) error
-	BeforeFunc        func(*cli.Context) error
-	AfterFunc         func(*cli.Context) error
-	Client            *http.Client
-	ConfigPath        string
-	IAMConfigPath     string `yaml:"iam_config_path"`
-	CACertificatePath string `yaml:"ca_certificate_path"`
+	App             *cli.App
+	Name            string
+	Endpoints       []string
+	Role            string
+	PollingInterval int
+	MetricsPort     int
+	MetricsScheme   string
+	MetricsHost     string
+	Log             *logrus.Entry
+	ConnectorFunc   func([]producers.MetricsMessage, *cli.Context) error
+	BeforeFunc      func(*cli.Context) error
+	AfterFunc       func(*cli.Context) error
+	Client          *http.Client
 }
 
 var version = "UNSET"
@@ -101,12 +96,6 @@ func New(options ...Option) (*Plugin, error) {
 			Value:       newPlugin.Role,
 			Usage:       "DC/OS role, either master or agent",
 			Destination: &newPlugin.Role,
-		},
-		cli.StringFlag{
-			Name:        "config",
-			Value:       newPlugin.ConfigPath,
-			Usage:       "The path to the config file.",
-			Destination: &newPlugin.ConfigPath,
 		},
 	}
 

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -118,7 +118,7 @@ func (p *Plugin) StartPlugin() error {
 		if p.BeforeFunc != nil {
 			return p.BeforeFunc(c)
 		}
-		return nil
+		return p.createClient()
 	}
 	p.App.After = func(c *cli.Context) error {
 		if p.AfterFunc != nil {
@@ -150,14 +150,6 @@ func (p *Plugin) StartPlugin() error {
 func (p *Plugin) Metrics() ([]producers.MetricsMessage, error) {
 
 	metricsMessages := []producers.MetricsMessage{}
-
-	// The first time Metrics() is called, the plugin client
-	// should be initialised
-	if p.Client == nil {
-		if err := p.createClient(); err != nil {
-			return metricsMessages, err
-		}
-	}
 
 	p.Log.Info("Getting metrics from metrics service")
 	if err := p.setEndpoints(); err != nil {

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,186 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -165,6 +165,12 @@
 			"revisionTime": "2016-04-14T09:54:25Z"
 		},
 		{
+			"checksumSHA1": "rJab1YdNhQooDiBWNnt7TLWPyBU=",
+			"path": "github.com/pkg/errors",
+			"revision": "f15c970de5b76fac0b59abb32d62c17cc7bed265",
+			"revisionTime": "2017-10-18T19:55:50Z"
+		},
+		{
 			"checksumSHA1": "cBeQQ9qg5iQrWGq8FSvVostq0vs=",
 			"path": "github.com/shirou/gopsutil",
 			"revision": "a63900a44bc14bcd39693da21afe001f57d567d3",


### PR DESCRIPTION
Metrics plugins have until now polled the dcos-metrics API via their local adminrouter. 

This meant that the user had to specify the location of adminrouter (it's on different ports on agents and masters) and it also caused problems on enterprise DC/OS, where SSL certificates had to be specified. 

Removing this allowed a good deal of code cleanup to take place, and [plugin.go](../tree/master/plugins/plugin.go) is almost completely rewritten as a result. 

More concretely, this fixes plugins on master nodes, which were not able to authenticate previously.

- Adds [DCOS_OSS-1876](https://jira.mesosphere.com/browse/DCOS_OSS-1876)
- Fixes [DCOS_OSS-1828](https://jira.mesosphere.com/browse/DCOS_OSS-1828)