### PR TITLE
Fix mesos module

### DIFF
--- a/mesos_module/isolator_module.cpp
+++ b/mesos_module/isolator_module.cpp
@@ -80,7 +80,8 @@ namespace metrics {
     }
 
     process::Future<Nothing> cleanup(
-        const mesos::ContainerID& container_id) {
+        const mesos::ContainerID& container_id,
+        const mesos::slave::ContainerConfig& container_config) {
       // If we are a nested container in the `DEBUG` class, then we don't
       // emit metrics from this container and hence have nothing to cleanup.
       if (!(container_id.has_parent() &&

--- a/mesos_module/isolator_module.hpp
+++ b/mesos_module/isolator_module.hpp
@@ -30,7 +30,8 @@ namespace metrics {
       const mesos::slave::ContainerConfig& container_config);
 
     process::Future<Nothing> cleanup(
-      const mesos::ContainerID& container_id);
+      const mesos::ContainerID& container_id,
+      const mesos::slave::ContainerConfig& container_config);
 
     // The following calls are unused by this implementation.
 


### PR DESCRIPTION
This PR hopefully fixes an error in #119 by declaring a variable (`container_config`) that was previously missing. 

See https://github.com/dcos/dcos/pull/2206 for test results. 