### PR TITLE
Ensure that Prometheus names cannot begin with numbers

### DIFF
--- a/producers/prometheus/prometheus_test.go
+++ b/producers/prometheus/prometheus_test.go
@@ -93,6 +93,7 @@ func TestSanitizeName(t *testing.T) {
 		io := map[string]string{
 			"abc":     "abc",
 			"abc123":  "abc123",
+			"123abc":  "_123abc",
 			"foo-bar": "foo_bar",
 			"foo:bar": "foo_bar",
 			"foo bar": "foo_bar",

--- a/producers/prometheus/prometheus_test.go
+++ b/producers/prometheus/prometheus_test.go
@@ -88,6 +88,21 @@ func TestRun(t *testing.T) {
 	})
 }
 
+func TestSanitizeName(t *testing.T) {
+	Convey("Should remove illegal metric name chars", t, func() {
+		io := map[string]string{
+			"abc":     "abc",
+			"abc123":  "abc123",
+			"foo-bar": "foo_bar",
+			"foo:bar": "foo_bar",
+			"foo bar": "foo_bar",
+		}
+		for i, o := range io {
+			So(sanitizeName(i), ShouldEqual, o)
+		}
+	})
+}
+
 // getEphemeralPort returns an available ephemeral port on the system.
 func getEphemeralPort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")


### PR DESCRIPTION
Some frameworks prefix metrics with hexidecimal UUIDs, leading to numeric initials in metrics. This is illegal in Prometheus. This PR adds a test and a fix. 

 - fixes [DCOS_OSS-2360](https://jira.mesosphere.com/browse/DCOS_OSS-2360) - Metric names can begin with numbers in dcos-metrics Prometheus endpoint

