### PR TITLE
Ensure that names cannot begin with numbers in Prometheus plugin

### DIFF
--- a/plugins/prometheus/prometheus_test.go
+++ b/plugins/prometheus/prometheus_test.go
@@ -156,6 +156,22 @@ func TestPromPlugin(t *testing.T) {
 	})
 }
 
+func TestSanitizeName(t *testing.T) {
+	Convey("Should remove illegal metric name chars", t, func() {
+		io := map[string]string{
+			"abc":     "abc",
+			"abc123":  "abc123",
+			"123abc":  "_123abc",
+			"foo-bar": "foo_bar",
+			"foo:bar": "foo_bar",
+			"foo bar": "foo_bar",
+		}
+		for i, o := range io {
+			So(sanitizeName(i), ShouldEqual, o)
+		}
+	})
+}
+
 // freeport listens momentarily on port 0, then closes the connection and
 // returns the assigned port, which is now known to be available.
 func freeport(t *testing.T) string {


### PR DESCRIPTION
This PR copies the changes from #142 into the Prometheus plugin to fix the same issue - it was possible for numbers to prefix Prometheus label names, which is illegal in Prometheus and caused such metrics to be ignored by the server. 