### PR TITLE
Label app stats

### DIFF
--- a/collectors/framework/record.go
+++ b/collectors/framework/record.go
@@ -64,6 +64,7 @@ func (ar avroRecord) extract(pmm *producers.MetricsMessage, ctr *mesosAgent.Cont
 				if info != nil {
 					pmm.Dimensions.TaskID = info.ID
 					pmm.Dimensions.TaskName = info.Name
+					pmm.Dimensions.Labels = convertLabels(info.Labels)
 				} else {
 					fwColLog.Debugf("Container ID %s had no associated task", tagValue)
 				}
@@ -111,6 +112,16 @@ func (ar avroRecord) extract(pmm *producers.MetricsMessage, ctr *mesosAgent.Cont
 	}
 
 	return fmt.Errorf("must have dcos.metrics.Tags or dcos.metrics.Datapoint in avro record to use .extract()")
+}
+
+// convertLabels converts each keyValue to an entry in a map
+func convertLabels(newLabels []mesosAgent.KeyValue) map[string]string {
+	result := map[string]string{}
+	for _, l := range newLabels {
+		result[l.Key] = l.Value
+	}
+
+	return result
 }
 
 // *avroRecord.createObjectFromRecord creates a JSON implementation of the avro

--- a/collectors/mesos/agent/agent.go
+++ b/collectors/mesos/agent/agent.go
@@ -94,8 +94,9 @@ func (ctr *ContainerTaskRels) update(as agentState) {
 			for _, t := range e.Tasks {
 				for _, s := range t.Statuses {
 					rels[s.ContainerStatusInfo.ID.Value] = &TaskInfo{
-						ID:   t.ID,
-						Name: t.Name,
+						ID:     t.ID,
+						Name:   t.Name,
+						Labels: t.Labels,
 					}
 				}
 			}

--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -433,8 +433,8 @@ func TestGetLabelsByContainerID(t *testing.T) {
 				Executors: []executorInfo{
 					executorInfo{
 						Container: "someContainerID",
-						Labels: []keyValue{
-							keyValue{
+						Labels: []KeyValue{
+							KeyValue{
 								Key:   "somekey",
 								Value: "someval",
 							},
@@ -442,12 +442,12 @@ func TestGetLabelsByContainerID(t *testing.T) {
 					},
 					executorInfo{
 						Container: "containerWithLongLabelID",
-						Labels: []keyValue{
-							keyValue{
+						Labels: []KeyValue{
+							KeyValue{
 								Key:   "somekey",
 								Value: "someval",
 							},
-							keyValue{
+							KeyValue{
 								Key:   "longkey",
 								Value: "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
 							},

--- a/collectors/mesos/agent/state.go
+++ b/collectors/mesos/agent/state.go
@@ -64,11 +64,12 @@ type executorInfo struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	Container string     `json:"container"`
-	Labels    []keyValue `json:"labels,omitempty"` // labels are optional
+	Labels    []KeyValue `json:"labels,omitempty"` // labels are optional
 	Tasks     []TaskInfo `json:"tasks,omitempty"`
 }
 
-type keyValue struct {
+// KeyValue is key and a value, each a string
+type KeyValue struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
@@ -77,7 +78,7 @@ type keyValue struct {
 type TaskInfo struct {
 	ID       string           `json:"id"`
 	Name     string           `json:"name"`
-	Labels   []keyValue       `json:"labels,omitempty"`
+	Labels   []KeyValue       `json:"labels,omitempty"`
 	Statuses []taskStatusInfo `json:"statuses,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds the labels on a mesos task to app statistics.

- fixes [DCOS_OSS-3304](https://jira.mesosphere.com/browse/DCOS_OSS-3304) - Metrics emitted by containers do not contain tags from labels

