### PR TITLE
Explicitly drop cosmos-related tags

### DIFF
--- a/collectors/mesos/agent/agent_test.go
+++ b/collectors/mesos/agent/agent_test.go
@@ -451,6 +451,10 @@ func TestGetLabelsByContainerID(t *testing.T) {
 								Key:   "longkey",
 								Value: "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
 							},
+							KeyValue{
+								Key:   "DCOS_PACKAGE_DEFINITION",
+								Value: "shortVal",
+							},
 						},
 					},
 				},
@@ -468,6 +472,11 @@ func TestGetLabelsByContainerID(t *testing.T) {
 		})
 
 		Convey("Should drop labels with overly long values", func() {
+			result := getLabelsByContainerID("containerWithLongLabelID", fi, tl)
+			So(result, ShouldResemble, map[string]string{"somekey": "someval"})
+		})
+
+		Convey("Should drop cosmos-related labels", func() {
 			result := getLabelsByContainerID("containerWithLongLabelID", fi, tl)
 			So(result, ShouldResemble, map[string]string{"somekey": "someval"})
 		})


### PR DESCRIPTION
- Fixes [DCOS-37451](https://jira.mesosphere.com/browse/DCOS-37451) - Filter cosmos bookkeeping tags from metrics