### PR TITLE
Modified Windows DCOS-Metrics to use detect_ip and clusterid file from the default path set by the dcos-go

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -100,7 +100,7 @@ if ($args.Count -eq 0)
     exit -1
 }
 
-Remove-Item .\build -Force -Recurse
+Remove-Item .\build -Force -Recurse -ErrorAction Ignore
 
 foreach ($arg in $args)
 {

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -121,6 +121,10 @@ function _unittest_with_coverage
         $package = Split-Path -Leaf $import_path
         Write-Output "Running tests for $import_path"
 
+        if ($import_path -eq 'github.com/dcos/dcos-metrics/vendor/github.com/coreos/go-systemd/activation') {
+            Write-Host("Skipped $import_path")
+            continue
+        }
         $covfile = ($BUILD_DIR + "/coverage-reports/profile_" + $package + ".cov")
         $repfile = ($BUILD_DIR + "/test-reports/" + $package + "-report.xml")
 
@@ -130,6 +134,7 @@ function _unittest_with_coverage
         $testoutput | Out-Default
         if ($LASTEXITCODE -ne 0) 
         {
+            Write-Host ("Failed to test $import_path")
             $numFailures = ($numFailures + 1)
         }
 #            fastfail("Unittests failed")

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/mesos.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/mesos.go
@@ -7,9 +7,10 @@ var ErrContainerIDNotFound = errors.New("invalid task. Container ID not found")
 
 // State stands for mesos state.json available via /mesos/master/state.json
 type State struct {
-	ID         string      `json:"id"`
-	Slaves     []Slave     `json:"slaves"`
-	Frameworks []Framework `json:"frameworks"`
+	ID                  string      `json:"id"`
+	Slaves              []Slave     `json:"slaves"`
+	Frameworks          []Framework `json:"frameworks"`
+	CompletedFrameworks []Framework `json:"completed_frameworks"`
 }
 
 // Slave is a field in state.json

--- a/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
+++ b/vendor/github.com/dcos/dcos-go/dcos/nodeutil/util.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	defaultExecTimeout = 10 * time.Second
+	defaultExecTimeout       = 10 * time.Second
+	defaultClusterIDLocation = "/var/lib/dcos/cluster-id"
 )
 
 // ErrTaskNotFound is return if the canonical ID for a given task not found.
@@ -99,15 +100,6 @@ func getDefaultShellPath() string {
 	}
 }
 
-func getClusterIDLocation() string {
-	switch runtime.GOOS {
-	case "windows":
-		return "/mesos/var/lib/dcos/cluster-id"
-	default:
-		return "/var/lib/dcos/cluster-id"
-	}
-}
-
 // NewNodeInfo returns a new instance of NodeInfo implementation.
 func NewNodeInfo(client *http.Client, role string, options ...Option) (NodeInfo, error) {
 	if client == nil {
@@ -138,7 +130,7 @@ func NewNodeInfo(client *http.Client, role string, options ...Option) (NodeInfo,
 		detectIPTimeout:   defaultExecTimeout,
 		dnsRecordLeader:   dcos.DNSRecordLeader,
 		mesosStateURL:     defaultStateURL.String(),
-		clusterIDLocation: getClusterIDLocation(),
+		clusterIDLocation: defaultClusterIDLocation,
 	}
 
 	// update parameters with a caller input.
@@ -390,6 +382,23 @@ func (d *dcosInfo) state(ctx context.Context) (state State, err error) {
 	return state, err
 }
 
+func findTask(name string, completed bool, frameworks []Framework) (foundTasks []Task) {
+	for _, framework := range frameworks {
+		currentTasks := framework.Tasks
+		if completed {
+			currentTasks = framework.CompletedTasks
+		}
+
+		for _, t := range currentTasks {
+			if t.Name != name && !strings.Contains(t.ID, name) {
+				continue
+			}
+			foundTasks = append(foundTasks, t)
+		}
+	}
+	return
+}
+
 // TaskCanonicalID return a CanonicalTaskID for a given task.
 func (d *dcosInfo) TaskCanonicalID(ctx context.Context, task string, completed bool) (*CanonicalTaskID, error) {
 	state, err := d.state(ctx)
@@ -397,20 +406,14 @@ func (d *dcosInfo) TaskCanonicalID(ctx context.Context, task string, completed b
 		return nil, err
 	}
 
-	var foundTasks []Task
-	for _, framework := range state.Frameworks {
-		currentTasks := framework.Tasks
-		if completed {
-			currentTasks = framework.CompletedTasks
-		}
+	frameworksTasks := findTask(task, completed, state.Frameworks)
 
-		for _, t := range currentTasks {
-			if t.Name != task && !strings.Contains(t.ID, task) {
-				continue
-			}
-			foundTasks = append(foundTasks, t)
-		}
+	var completedFrameworksTasks []Task
+	if completed {
+		completedFrameworksTasks = findTask(task, completed, state.CompletedFrameworks)
 	}
+
+	foundTasks := append(frameworksTasks, completedFrameworksTasks...)
 
 	if len(foundTasks) == 0 {
 		return nil, ErrTaskNotFound

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -73,10 +73,10 @@
 			"revisionTime": "2017-12-07T19:43:51Z"
 		},
 		{
-			"checksumSHA1": "MnOuioF+o+gamskiD28LRbq5EyU=",
+			"checksumSHA1": "59TTuicR7fFqMWZ+8chOcynF1Vo=",
 			"path": "github.com/dcos/dcos-go/dcos/nodeutil",
-			"revision": "4dd6c8d149dc706729bd0f617211a539717a6132",
-			"revisionTime": "2017-12-07T19:43:51Z"
+			"revision": "95000f9090913360b907002f4a38f30ab077c5ee",
+			"revisionTime": "2018-05-12T14:06:00Z"
 		},
 		{
 			"checksumSHA1": "mCuoKmG5BojkBOtcDfvXsRLipIk=",


### PR DESCRIPTION
There are three separate commits included in this PR for addressing the following three issues

1. Made the dcos-metrics uses the detect_ip and clusterid files from the default paths
2. Ignored error from deleting non-exiting build directory
3. Removed the Linux only coreos/go-systemd/activation package from Windows unitests run