### PR TITLE
Updated prometheus-dcos19.md vim->vi

### DIFF
--- a/docs/quickstart/prometheus-dcos19.md
+++ b/docs/quickstart/prometheus-dcos19.md
@@ -29,7 +29,7 @@ $ curl -o /etc/systemd/system/dcos-metrics-prometheus.service -L https://downloa
 
 Change the --dcos-role flag to ‘agent’, ‘agent_public' or ‘master'
 ```
-$ vim /etc/systemd/system/dcos-metrics-prometheus.service
+$ vi /etc/systemd/system/dcos-metrics-prometheus.service
 ```
 
 Load the new configuration and start the plugin


### PR DESCRIPTION
Since `vim` isn't setup on Centos by default I'm proposing to change this in `vi`