### PR TITLE
Add debug route

### DIFF
--- a/producers/http/handlers.go
+++ b/producers/http/handlers.go
@@ -25,6 +25,23 @@ import (
 	"github.com/gorilla/mux"
 )
 
+func debugHandler(p *producerImpl) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		allMetrics := p.store.Objects()
+		if len(allMetrics) == 0 {
+			httpLog.Error("/v0/debug - no content in store.")
+			http.Error(w, "No values found in store", http.StatusNoContent)
+		}
+
+		combinedMetrics, err := combineMessages(allMetrics)
+		if err != nil {
+			httpLog.Errorf("/v0/debug - %s", err.Error())
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		encode(combinedMetrics, w)
+	}
+}
+
 func nodeHandler(p *producerImpl) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		nodeMetrics, err := p.store.GetByRegex(regexp.QuoteMeta(producers.NodeMetricPrefix) + ".*")

--- a/producers/http/routes.go
+++ b/producers/http/routes.go
@@ -66,6 +66,13 @@ var routes = []Route{
 		Path:        strings.Join([]string{root, "node"}, "/"),
 		HandlerFunc: nodeHandler,
 	},
+
+	Route{
+		Name:        "debug",
+		Method:      "GET",
+		Path:        strings.Join([]string{root, "debug"}, "/"),
+		HandlerFunc: debugHandler,
+	},
 }
 
 var agentRoutes = []Route{

--- a/producers/prometheus/prometheus.go
+++ b/producers/prometheus/prometheus.go
@@ -151,7 +151,7 @@ func (p *promProducer) Collect(ch chan<- prometheus.Metric) {
 			name := sanitizeName(d.Name)
 			val, err := coerceToFloat(d.Value)
 			if err != nil {
-				promLog.Warnf("Bad datapoint value %q: %s", d.Value, err)
+				promLog.Warnf("Bad datapoint value %q: (%s) %s", d.Value, d.Name, err)
 				continue
 			}
 			desc := prometheus.NewDesc(name, "DC/OS Metrics Datapoint", tagKeys, nil)


### PR DESCRIPTION
This PR adds a /debug route to the v0 API, which shows all metrics currently in the store. 

- Partially fixes [DCOS-37454](https://jira.mesosphere.com/browse/DCOS-37454)