### PR TITLE
Fix errors that occur while testing with go 1.11

### DIFF
--- a/plugins/datadog-standalone/datadog-standalone_test.go
+++ b/plugins/datadog-standalone/datadog-standalone_test.go
@@ -108,7 +108,7 @@ func TestPostMetricsToDatadog(t *testing.T) {
 		}
 
 		if *uptime.Host != "192.168.65.90" {
-			t.Fatalf("Expected to find host 192.168.65.90, found %s", uptime.Host)
+			t.Fatalf("Expected to find host 192.168.65.90, found %v", uptime.Host)
 		}
 
 		statsdUptime := series.Series[4]

--- a/plugins/statsd/statsd.go
+++ b/plugins/statsd/statsd.go
@@ -127,7 +127,7 @@ func normalize(i interface{}) (int, error) {
 		// We need this check here because NaN can be a float. Casting NaN to
 		// int results in a large negative number. Even after you add 0.5.
 		if math.IsNaN(v) {
-			return -1, fmt.Errorf("Could not normalize NaN %q", v)
+			return -1, fmt.Errorf("Could not normalize NaN %v", v)
 		}
 		return int(v + 0.5), nil
 	case string:


### PR DESCRIPTION
# The following errors occur while running the tests with GO version 1.11.1
```
Running tests for github.com/dcos/dcos-metrics/plugins/statsd
Calling: & go test -v -tags="unit" -covermode=count -coverprofile=C:/Users/Administrator/golang/src/github.com/dcos/dcos-metrics/build/collector/coverage-reports/profile_statsd.cov github.com/dcos/dcos-metrics/plugins/statsd
# github.com/dcos/dcos-metrics/plugins/statsd
plugins\statsd\statsd.go:130: Errorf format %q has arg v of wrong type float64
FAIL    github.com/dcos/dcos-metrics/plugins/statsd [build failed]
Failed to test github.com/dcos/dcos-metrics/plugins/statsd


Running tests for github.com/dcos/dcos-metrics/plugins/datadog-standalone
Calling: & go test -v -tags="unit" -covermode=count -coverprofile=C:/Users/Administrator/golang/src/github.com/dcos/dcos-metrics/build/collector/coverage-reports/profile_datadog-standalone.cov github.com/dcos/dcos-metrics/plugins/datadog-standalone
# github.com/dcos/dcos-metrics/plugins/datadog-standalone
plugins\datadog-standalone\datadog-standalone_test.go:111: T.Fatalf format %s has arg uptime.Host of wrong type *string
FAIL    github.com/dcos/dcos-metrics/plugins/datadog-standalone [build failed]
Failed to test github.com/dcos/dcos-metrics/plugins/datadog-standalone
```

