### PR TITLE
Handle multiple systemd sockets

### DIFF
--- a/producers/http/http.go
+++ b/producers/http/http.go
@@ -94,7 +94,7 @@ func (p *producerImpl) Run() error {
 
 	r := newRouter(p)
 
-	listeners, err := getListener(true)
+	listeners, err := getListener()
 	if err != nil {
 		return fmt.Errorf("Unable to get listeners: %s", err)
 	}

--- a/producers/http/listener_darwin.go
+++ b/producers/http/listener_darwin.go
@@ -19,7 +19,7 @@ import (
 	"os"
 )
 
-func getListener(unsetEnv bool) ([]net.Listener, error) {
+func getListener() ([]net.Listener, error) {
 	return nil, nil
 }
 

--- a/producers/http/listener_linux.go
+++ b/producers/http/listener_linux.go
@@ -21,7 +21,7 @@ import (
 	"github.com/coreos/go-systemd/activation"
 )
 
-func getListener(unsetEnv bool) ([]net.Listener, error) {
+func getListener() ([]net.Listener, error) {
 	return activation.Listeners()
 }
 

--- a/producers/http/listener_windows.go
+++ b/producers/http/listener_windows.go
@@ -19,7 +19,7 @@ import (
 	"os"
 )
 
-func getListener(unsetEnv bool) ([]net.Listener, error) {
+func getListener() ([]net.Listener, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This adds a Listener field to the HTTP producer's `Config` struct. This can be used to directly provide a listener for the HTTP producer to serve on, rather than leaving it to infer a listener from the environment or config.

https://jira.mesosphere.com/browse/DCOS_OSS-4465